### PR TITLE
refactor(x/crosschain): HasBridgeToken use GetBridgeDenomKey instead of GetTokenToDenomKey

### DIFF
--- a/x/crosschain/keeper/bridge_token.go
+++ b/x/crosschain/keeper/bridge_token.go
@@ -68,7 +68,7 @@ func (k Keeper) GetContractByBridgeDenom(ctx sdk.Context, bridgeDenom string) (s
 
 func (k Keeper) HasBridgeToken(ctx sdk.Context, denom string) bool {
 	store := ctx.KVStore(k.storeKey)
-	return store.Has(types.GetTokenToDenomKey(denom))
+	return store.Has(types.GetBridgeDenomKey(denom))
 }
 
 func (k Keeper) AddBridgeToken(ctx sdk.Context, bridgeDenom, baseDenom string) {

--- a/x/crosschain/keeper/bridge_token_test.go
+++ b/x/crosschain/keeper/bridge_token_test.go
@@ -18,6 +18,7 @@ func (suite *KeeperTestSuite) TestKeeper_BridgeTokenCase() {
 		getBridgeDenomByContract map[string]string
 		getContractByBridgeDenom map[string]string
 		allBridgeTokenLen        int
+		malleate                 func(claim *types.MsgBridgeTokenClaim)
 	}{
 		{
 			name: "success with FX symbol",
@@ -50,10 +51,25 @@ func (suite *KeeperTestSuite) TestKeeper_BridgeTokenCase() {
 			},
 			allBridgeTokenLen: 1,
 		},
+		{
+			name: "err duplicate token contract",
+			claim: &types.MsgBridgeTokenClaim{
+				TokenContract: "0x1",
+			},
+			pass: false,
+			malleate: func(claim *types.MsgBridgeTokenClaim) {
+				err := suite.Keeper().AddBridgeTokenExecuted(suite.Ctx, claim)
+				suite.Require().NoError(err)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
+			if tc.malleate != nil {
+				tc.malleate(tc.claim)
+			}
+
 			err := suite.Keeper().AddBridgeTokenExecuted(suite.Ctx, tc.claim)
 			if !tc.pass {
 				suite.Require().Error(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated logic for checking the existence of bridge tokens, enhancing the reliability of token management.
	- Introduced a new test case to ensure proper handling of duplicate token contracts.

- **Bug Fixes**
	- Improved error handling for duplicate token contract scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->