### PR TITLE
refactor(x/crosschain): rename queryServer to server

### DIFF
--- a/x/crosschain/keeper/msg_server_router.go
+++ b/x/crosschain/keeper/msg_server_router.go
@@ -23,122 +23,122 @@ func NewMsgServerRouterImpl(routerKeeper RouterKeeper) types.MsgServer {
 var _ types.MsgServer = msgServer{}
 
 func (k msgServer) BondedOracle(ctx context.Context, msg *types.MsgBondedOracle) (*types.MsgBondedOracleResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.BondedOracle(ctx, msg)
+		return server.BondedOracle(ctx, msg)
 	}
 }
 
 func (k msgServer) AddDelegate(ctx context.Context, msg *types.MsgAddDelegate) (*types.MsgAddDelegateResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.AddDelegate(ctx, msg)
+		return server.AddDelegate(ctx, msg)
 	}
 }
 
 func (k msgServer) ReDelegate(ctx context.Context, msg *types.MsgReDelegate) (*types.MsgReDelegateResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.ReDelegate(ctx, msg)
+		return server.ReDelegate(ctx, msg)
 	}
 }
 
 func (k msgServer) EditBridger(ctx context.Context, msg *types.MsgEditBridger) (*types.MsgEditBridgerResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.EditBridger(ctx, msg)
+		return server.EditBridger(ctx, msg)
 	}
 }
 
 func (k msgServer) WithdrawReward(ctx context.Context, msg *types.MsgWithdrawReward) (*types.MsgWithdrawRewardResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.WithdrawReward(ctx, msg)
+		return server.WithdrawReward(ctx, msg)
 	}
 }
 
 func (k msgServer) UnbondedOracle(ctx context.Context, msg *types.MsgUnbondedOracle) (*types.MsgUnbondedOracleResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.UnbondedOracle(ctx, msg)
+		return server.UnbondedOracle(ctx, msg)
 	}
 }
 
 func (k msgServer) OracleSetConfirm(ctx context.Context, msg *types.MsgOracleSetConfirm) (*types.MsgOracleSetConfirmResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.OracleSetConfirm(ctx, msg)
+		return server.OracleSetConfirm(ctx, msg)
 	}
 }
 
 func (k msgServer) SendToExternal(ctx context.Context, msg *types.MsgSendToExternal) (*types.MsgSendToExternalResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.SendToExternal(ctx, msg)
+		return server.SendToExternal(ctx, msg)
 	}
 }
 
 func (k msgServer) CancelSendToExternal(ctx context.Context, msg *types.MsgCancelSendToExternal) (*types.MsgCancelSendToExternalResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.CancelSendToExternal(ctx, msg)
+		return server.CancelSendToExternal(ctx, msg)
 	}
 }
 
 func (k msgServer) IncreaseBridgeFee(ctx context.Context, msg *types.MsgIncreaseBridgeFee) (*types.MsgIncreaseBridgeFeeResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.IncreaseBridgeFee(ctx, msg)
+		return server.IncreaseBridgeFee(ctx, msg)
 	}
 }
 
 func (k msgServer) RequestBatch(ctx context.Context, msg *types.MsgRequestBatch) (*types.MsgRequestBatchResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.RequestBatch(ctx, msg)
+		return server.RequestBatch(ctx, msg)
 	}
 }
 
 func (k msgServer) ConfirmBatch(ctx context.Context, msg *types.MsgConfirmBatch) (*types.MsgConfirmBatchResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.ConfirmBatch(ctx, msg)
+		return server.ConfirmBatch(ctx, msg)
 	}
 }
 
 func (k msgServer) BridgeCallConfirm(ctx context.Context, msg *types.MsgBridgeCallConfirm) (*types.MsgBridgeCallConfirmResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.BridgeCallConfirm(ctx, msg)
+		return server.BridgeCallConfirm(ctx, msg)
 	}
 }
 
 func (k msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.UpdateParams(ctx, msg)
+		return server.UpdateParams(ctx, msg)
 	}
 }
 
 func (k msgServer) UpdateChainOracles(ctx context.Context, msg *types.MsgUpdateChainOracles) (*types.MsgUpdateChainOraclesResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.UpdateChainOracles(ctx, msg)
+		return server.UpdateChainOracles(ctx, msg)
 	}
 }
 
@@ -159,17 +159,17 @@ func (k msgServer) getMsgServerByChainName(chainName string) (types.MsgServer, e
 }
 
 func (k msgServer) Claim(ctx context.Context, msg *types.MsgClaim) (*types.MsgClaimResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.Claim(ctx, msg)
+		return server.Claim(ctx, msg)
 	}
 }
 
 func (k msgServer) Confirm(ctx context.Context, msg *types.MsgConfirm) (*types.MsgConfirmResponse, error) {
-	if queryServer, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
+	if server, err := k.getMsgServerByChainName(msg.GetChainName()); err != nil {
 		return nil, err
 	} else {
-		return queryServer.Confirm(ctx, msg)
+		return server.Confirm(ctx, msg)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Renamed the variable `queryServer` to `server` in multiple methods for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->