### PR TITLE
refactor(x/evm): rename ERE20 to ERC20

### DIFF
--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -13,17 +13,17 @@ import (
 
 // QueryERC20 returns the data of a deployed ERC20 contract
 func (k Keeper) QueryERC20(ctx sdk.Context, contractAddr common.Address) (types.ERC20Data, error) {
-	name, err := k.evmErc20Keeper.ERE20Name(ctx, contractAddr)
+	name, err := k.evmErc20Keeper.ERC20Name(ctx, contractAddr)
 	if err != nil {
 		return types.ERC20Data{}, err
 	}
 
-	symbol, err := k.evmErc20Keeper.ERE20Symbol(ctx, contractAddr)
+	symbol, err := k.evmErc20Keeper.ERC20Symbol(ctx, contractAddr)
 	if err != nil {
 		return types.ERC20Data{}, err
 	}
 
-	decimals, err := k.evmErc20Keeper.ERE20Decimals(ctx, contractAddr)
+	decimals, err := k.evmErc20Keeper.ERC20Decimals(ctx, contractAddr)
 	if err != nil {
 		return types.ERC20Data{}, err
 	}

--- a/x/erc20/keeper/msg_server.go
+++ b/x/erc20/keeper/msg_server.go
@@ -190,7 +190,7 @@ func (k Keeper) ConvertCoinNativeCoin(ctx sdk.Context, pair types.TokenPair, sen
 	erc20Contract := pair.GetERC20Contract()
 
 	// Mint Tokens and send to receiver
-	if err := k.evmErc20Keeper.ERE20Mint(ctx, erc20Contract, k.moduleAddress, receiver, coin.Amount.BigInt()); err != nil {
+	if err := k.evmErc20Keeper.ERC20Mint(ctx, erc20Contract, k.moduleAddress, receiver, coin.Amount.BigInt()); err != nil {
 		return err
 	}
 
@@ -211,7 +211,7 @@ func (k Keeper) ConvertERC20NativeCoin(ctx sdk.Context, pair types.TokenPair, se
 	erc20Contract := pair.GetERC20Contract()
 
 	// Burn escrowed tokens
-	if err := k.evmErc20Keeper.ERE20Burn(ctx, erc20Contract, k.moduleAddress, sender, amount.BigInt()); err != nil {
+	if err := k.evmErc20Keeper.ERC20Burn(ctx, erc20Contract, k.moduleAddress, sender, amount.BigInt()); err != nil {
 		return err
 	}
 
@@ -242,7 +242,7 @@ func (k Keeper) ConvertERC20NativeCoin(ctx sdk.Context, pair types.TokenPair, se
 func (k Keeper) ConvertERC20NativeToken(ctx sdk.Context, pair types.TokenPair, sender common.Address, receiver sdk.AccAddress, amount sdkmath.Int) error {
 	// Escrow tokens on module account
 	erc20Contract := pair.GetERC20Contract()
-	if err := k.evmErc20Keeper.ERE20Transfer(ctx, erc20Contract, sender, k.moduleAddress, amount.BigInt()); err != nil {
+	if err := k.evmErc20Keeper.ERC20Transfer(ctx, erc20Contract, sender, k.moduleAddress, amount.BigInt()); err != nil {
 		return err
 	}
 
@@ -278,7 +278,7 @@ func (k Keeper) ConvertCoinNativeERC20(ctx sdk.Context, pair types.TokenPair, se
 	}
 
 	// Unescrow Tokens and send to receiver
-	if err := k.evmErc20Keeper.ERE20Transfer(ctx, pair.GetERC20Contract(), k.moduleAddress, receiver, coin.Amount.BigInt()); err != nil {
+	if err := k.evmErc20Keeper.ERC20Transfer(ctx, pair.GetERC20Contract(), k.moduleAddress, receiver, coin.Amount.BigInt()); err != nil {
 		return err
 	}
 

--- a/x/erc20/types/expected_keepers.go
+++ b/x/erc20/types/expected_keepers.go
@@ -34,13 +34,13 @@ type BankKeeper interface {
 }
 
 type EvmERC20Keeper interface {
-	ERE20Name(ctx context.Context, contractAddr common.Address) (string, error)
-	ERE20Symbol(ctx context.Context, contractAddr common.Address) (string, error)
-	ERE20Decimals(ctx context.Context, contractAddr common.Address) (uint8, error)
+	ERC20Name(ctx context.Context, contractAddr common.Address) (string, error)
+	ERC20Symbol(ctx context.Context, contractAddr common.Address) (string, error)
+	ERC20Decimals(ctx context.Context, contractAddr common.Address) (uint8, error)
 
-	ERE20Mint(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error
-	ERE20Burn(ctx context.Context, contractAddr common.Address, from, account common.Address, amount *big.Int) error
-	ERE20Transfer(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error
+	ERC20Mint(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error
+	ERC20Burn(ctx context.Context, contractAddr common.Address, from, account common.Address, amount *big.Int) error
+	ERC20Transfer(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error
 }
 
 // EVMKeeper defines the expected EVM keeper interface used on erc20

--- a/x/evm/keeper/erc20.go
+++ b/x/evm/keeper/erc20.go
@@ -13,7 +13,7 @@ import (
 	"github.com/functionx/fx-core/v8/x/evm/types"
 )
 
-func (k *Keeper) ERE20Name(ctx context.Context, contractAddr common.Address) (string, error) {
+func (k *Keeper) ERC20Name(ctx context.Context, contractAddr common.Address) (string, error) {
 	var nameRes struct{ Value string }
 	if err := k.QueryContract(sdk.UnwrapSDKContext(ctx), k.module, contractAddr, contract.GetFIP20().ABI, "name", &nameRes); err != nil {
 		return "", err
@@ -21,7 +21,7 @@ func (k *Keeper) ERE20Name(ctx context.Context, contractAddr common.Address) (st
 	return nameRes.Value, nil
 }
 
-func (k *Keeper) ERE20Symbol(ctx context.Context, contractAddr common.Address) (string, error) {
+func (k *Keeper) ERC20Symbol(ctx context.Context, contractAddr common.Address) (string, error) {
 	var symbolRes struct{ Value string }
 	if err := k.QueryContract(sdk.UnwrapSDKContext(ctx), k.module, contractAddr, contract.GetFIP20().ABI, "symbol", &symbolRes); err != nil {
 		return "", err
@@ -29,7 +29,7 @@ func (k *Keeper) ERE20Symbol(ctx context.Context, contractAddr common.Address) (
 	return symbolRes.Value, nil
 }
 
-func (k *Keeper) ERE20Decimals(ctx context.Context, contractAddr common.Address) (uint8, error) {
+func (k *Keeper) ERC20Decimals(ctx context.Context, contractAddr common.Address) (uint8, error) {
 	var decimalRes struct{ Value uint8 }
 	if err := k.QueryContract(sdk.UnwrapSDKContext(ctx), k.module, contractAddr, contract.GetFIP20().ABI, "decimals", &decimalRes); err != nil {
 		return 0, nil
@@ -47,17 +47,17 @@ func (k *Keeper) ERC20BalanceOf(ctx context.Context, contractAddr, addr common.A
 	return balanceRes.Value, nil
 }
 
-func (k *Keeper) ERE20Mint(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error {
+func (k *Keeper) ERC20Mint(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error {
 	_, err := k.ApplyContract(sdk.UnwrapSDKContext(ctx), from, contractAddr, nil, contract.GetFIP20().ABI, "mint", receiver, amount)
 	return err
 }
 
-func (k *Keeper) ERE20Burn(ctx context.Context, contractAddr common.Address, from, account common.Address, amount *big.Int) error {
+func (k *Keeper) ERC20Burn(ctx context.Context, contractAddr common.Address, from, account common.Address, amount *big.Int) error {
 	_, err := k.ApplyContract(sdk.UnwrapSDKContext(ctx), from, contractAddr, nil, contract.GetFIP20().ABI, "burn", account, amount)
 	return err
 }
 
-func (k *Keeper) ERE20Transfer(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error {
+func (k *Keeper) ERC20Transfer(ctx context.Context, contractAddr common.Address, from, receiver common.Address, amount *big.Int) error {
 	erc20ABI := contract.GetFIP20().ABI
 	res, err := k.ApplyContract(sdk.UnwrapSDKContext(ctx), from, contractAddr, nil, erc20ABI, "transfer", receiver, amount)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Standardized naming conventions for ERC20-related methods to enhance clarity and consistency.
	- Updated method names for querying and interacting with ERC20 contracts.

- **Bug Fixes**
	- No functional changes, but improved naming may resolve potential confusion regarding method usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->