### PR TITLE
refactor: rename BridgeCallFeeUpgradeable to BridgeCallFee

### DIFF
--- a/solidity/contracts/bridge/BridgeCallFee.sol
+++ b/solidity/contracts/bridge/BridgeCallFee.sol
@@ -12,7 +12,7 @@ import {IBridgeCallback} from "./IBridgeCallback.sol";
 
 /* solhint-disable custom-errors */
 
-contract BridgeCallFeeUpgradeable is
+contract BridgeCallFee is
     IBridgeCallback,
     Initializable,
     ContextUpgradeable,

--- a/solidity/test/bridge_fee.ts
+++ b/solidity/test/bridge_fee.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import {
   ERC20TokenTest,
   FxBridgeLogic,
-  BridgeCallFeeUpgradeable,
+  BridgeCallFee,
   BridgeCallbackTest,
 } from "../typechain-types";
 import { AbiCoder, encodeBytes32String } from "ethers";
@@ -16,7 +16,7 @@ describe("submit bridge call tests", function () {
   let user1: HardhatEthersSigner;
   let erc20Token: ERC20TokenTest;
   let fxBridge: FxBridgeLogic;
-  let bridgeCallFee: BridgeCallFeeUpgradeable;
+  let bridgeCallFee: BridgeCallFee;
   let bridgeCallback: BridgeCallbackTest;
 
   let token1: ERC20TokenTest;
@@ -94,7 +94,7 @@ describe("submit bridge call tests", function () {
     await erc20Token.transferOwnership(await fxBridge.getAddress());
 
     const bridgeCallFeeFactory = await ethers.getContractFactory(
-      "BridgeCallFeeUpgradeable"
+      "BridgeCallFee"
     );
     const bridgeCallFeeDeploy = await bridgeCallFeeFactory.deploy();
 
@@ -107,7 +107,7 @@ describe("submit bridge call tests", function () {
     );
 
     bridgeCallFee = await ethers.getContractAt(
-      "BridgeCallFeeUpgradeable",
+      "BridgeCallFee",
       await bridgeCallFeeProxy.getAddress()
     );
     await bridgeCallFee.initialize(await fxBridge.getAddress());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The contract has been renamed to `BridgeCallFee`, maintaining its original functionality for managing bridge fees and callbacks.
	- Introduced methods for updating the bridge address, processing incoming tokens, and withdrawing accumulated fees.

- **Bug Fixes**
	- Updated test references to ensure consistency with the renamed contract, enhancing reliability in testing the bridge fee mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->