### PR TITLE
refactor: reset timeout and confirmation data for crosschain transaction timeout

### DIFF
--- a/x/crosschain/keeper/bridge_call_out_test.go
+++ b/x/crosschain/keeper/bridge_call_out_test.go
@@ -36,6 +36,7 @@ func (s *KeeperMockSuite) TestKeeper_BridgeCallResultHandler() {
 
 			s.accountKeeper.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			s.accountKeeper.EXPECT().NewAccountWithAddress(gomock.Any(), gomock.Any()).Times(1)
+			s.erc20Keeper.EXPECT().DeleteCache(gomock.Any(), gomock.Any()).Times(1)
 
 			s.crosschainKeeper.SetOutgoingBridgeCall(s.ctx, &types.OutgoingBridgeCall{
 				Sender:      helpers.GenExternalAddr(s.moduleName),

--- a/x/crosschain/types/events.go
+++ b/x/crosschain/types/events.go
@@ -24,11 +24,6 @@ const (
 	AttributeKeyOutgoingBatchNonce   = "batch_nonce"
 	AttributeKeyOutgoingBatchTimeout = "outgoing_batch_timeout"
 
-	EventTypeIbcTransfer         = "ibc_transfer"
-	AttributeKeyIbcSendSequence  = "ibc_send_sequence"
-	AttributeKeyIbcSourcePort    = "ibc_source_port"
-	AttributeKeyIbcSourceChannel = "ibc_source_channel"
-
 	EventTypeEvmTransfer = "evm_transfer"
 
 	EventTypeBridgeCallEvent = "bridge_call_event"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of outgoing transaction batches with new logic for resending timed-out batches.
	- Improved error handling for bridge call operations.

- **Bug Fixes**
	- Added error propagation for bridge call record deletions to prevent silent failures.

- **Documentation**
	- Clarified comments in code regarding oracle set pruning and attestation management.

- **Chores**
	- Removed unnecessary constants related to IBC transfer events, streamlining event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->