### PR TITLE
chore: migrate OutgoingTxBatchBlockKey with batch nonce

### DIFF
--- a/x/crosschain/keeper/migrations.go
+++ b/x/crosschain/keeper/migrations.go
@@ -17,7 +17,7 @@ func NewMigrator(k Keeper) Migrator {
 }
 
 func (m Migrator) Migrate7to8(ctx sdk.Context) error {
-	return v8.Migrate(ctx, m.keeper.storeKey)
+	return v8.Migrate(ctx, m.keeper.storeKey, m.keeper.cdc)
 }
 
 func (m Migrator) Migrate7to8WithArbExternalBlockTime(ctx sdk.Context) error {

--- a/x/crosschain/keeper/outgoing_tx.go
+++ b/x/crosschain/keeper/outgoing_tx.go
@@ -115,7 +115,7 @@ func (k Keeper) StoreBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) error 
 	key := types.GetOutgoingTxBatchKey(batch.TokenContract, batch.BatchNonce)
 	store.Set(key, k.cdc.MustMarshal(batch))
 
-	blockKey := types.GetOutgoingTxBatchBlockKey(batch.Block)
+	blockKey := types.GetOutgoingTxBatchBlockKey(batch.Block, batch.BatchNonce)
 	// Note: Only one OutgoingTxBatch can be submitted in a block
 	if store.Has(blockKey) {
 		return types.ErrInvalid.Wrapf("block:[%v] has batch request", batch.Block)
@@ -128,7 +128,7 @@ func (k Keeper) StoreBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) error 
 func (k Keeper) DeleteBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetOutgoingTxBatchKey(batch.TokenContract, batch.BatchNonce))
-	store.Delete(types.GetOutgoingTxBatchBlockKey(batch.Block))
+	store.Delete(types.GetOutgoingTxBatchBlockKey(batch.Block, batch.BatchNonce))
 }
 
 // GetOutgoingTxBatch loads a batch object. Returns nil when not exists.

--- a/x/crosschain/migrations/v8/migrate.go
+++ b/x/crosschain/migrations/v8/migrate.go
@@ -49,10 +49,11 @@ func migrateOutgoingTxBatchBlockKey(ctx sdk.Context, storeKey storetypes.StoreKe
 		batch := new(types.OutgoingTxBatch)
 		cdc.MustUnmarshal(iter.Value(), batch)
 		batches = append(batches, batch)
+		kvStore.Delete(iter.Key())
 	}
 
 	for _, batch := range batches {
-		blockKey := types.GetOutgoingTxBatchBlockKey(batch.Block, batch.BatchNonce)
-		kvStore.Set(blockKey, cdc.MustMarshal(batch))
+		newBlockKey := types.GetOutgoingTxBatchBlockKey(batch.Block, batch.BatchNonce)
+		kvStore.Set(newBlockKey, cdc.MustMarshal(batch))
 	}
 }

--- a/x/crosschain/migrations/v8/migrate.go
+++ b/x/crosschain/migrations/v8/migrate.go
@@ -2,9 +2,11 @@ package v8
 
 import (
 	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/functionx/fx-core/v8/app/upgrades/store"
+	"github.com/functionx/fx-core/v8/x/crosschain/types"
 )
 
 var (
@@ -31,7 +33,26 @@ func GetRemovedStoreKeys() [][]byte {
 	}
 }
 
-func Migrate(ctx sdk.Context, storeKey storetypes.StoreKey) error {
+func Migrate(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
 	store.RemoveStoreKeys(ctx, storeKey, GetRemovedStoreKeys())
+	migrateOutgoingTxBatchBlockKey(ctx, storeKey, cdc)
 	return nil
+}
+
+func migrateOutgoingTxBatchBlockKey(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) {
+	kvStore := ctx.KVStore(storeKey)
+	iter := storetypes.KVStorePrefixIterator(kvStore, types.OutgoingTxBatchBlockKey)
+	defer iter.Close()
+
+	batches := make([]*types.OutgoingTxBatch, 0, 100)
+	for ; iter.Valid(); iter.Next() {
+		batch := new(types.OutgoingTxBatch)
+		cdc.MustUnmarshal(iter.Value(), batch)
+		batches = append(batches, batch)
+	}
+
+	for _, batch := range batches {
+		blockKey := types.GetOutgoingTxBatchBlockKey(batch.Block, batch.BatchNonce)
+		kvStore.Set(blockKey, cdc.MustMarshal(batch))
+	}
 }

--- a/x/crosschain/types/key.go
+++ b/x/crosschain/types/key.go
@@ -171,8 +171,8 @@ func GetOutgoingTxBatchKey(tokenContract string, batchNonce uint64) []byte {
 }
 
 // GetOutgoingTxBatchBlockKey returns the following key format
-func GetOutgoingTxBatchBlockKey(blockHeight uint64) []byte {
-	return append(OutgoingTxBatchBlockKey, sdk.Uint64ToBigEndian(blockHeight)...)
+func GetOutgoingTxBatchBlockKey(blockHeight, batchNonce uint64) []byte {
+	return append(append(OutgoingTxBatchBlockKey, sdk.Uint64ToBigEndian(blockHeight)...), sdk.Uint64ToBigEndian(batchNonce)...)
 }
 
 // GetBatchConfirmKey returns the following key format


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced testing for application upgrades, including checks for outgoing transaction batches.
  - Improved migration functionality for processing outgoing transaction batches during upgrades.

- **Bug Fixes**
  - Addressed potential key collisions in outgoing transaction batch management by incorporating batch nonce into key generation.

- **Documentation**
  - Updated function signatures to reflect new parameters and improve clarity on migration processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->