### PR TITLE
refactor: eliminate unnecessary nil check in BigEndianToUint64 function

### DIFF
--- a/x/crosschain/keeper/attestation.go
+++ b/x/crosschain/keeper/attestation.go
@@ -246,10 +246,5 @@ func (k Keeper) SetLastEventBlockHeightByOracle(ctx sdk.Context, oracleAddr sdk.
 // GetLastEventBlockHeightByOracle get the latest event blockHeight for a give oracle
 func (k Keeper) GetLastEventBlockHeightByOracle(ctx sdk.Context, oracleAddr sdk.AccAddress) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	key := types.GetLastEventBlockHeightByOracleKey(oracleAddr)
-	if !store.Has(key) {
-		return 0
-	}
-	data := store.Get(key)
-	return sdk.BigEndianToUint64(data)
+	return sdk.BigEndianToUint64(store.Get(types.GetLastEventBlockHeightByOracleKey(oracleAddr)))
 }

--- a/x/crosschain/keeper/batch_confirm.go
+++ b/x/crosschain/keeper/batch_confirm.go
@@ -65,11 +65,7 @@ func (k Keeper) SetLastSlashedBatchBlock(ctx sdk.Context, blockHeight uint64) {
 // GetLastSlashedBatchBlock returns the latest slashed Batch block
 func (k Keeper) GetLastSlashedBatchBlock(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get(types.LastSlashedBatchBlock)
-	if len(bytes) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(bytes)
+	return sdk.BigEndianToUint64(store.Get(types.LastSlashedBatchBlock))
 }
 
 // GetUnSlashedBatches returns all the unSlashed batches in state

--- a/x/crosschain/keeper/observed.go
+++ b/x/crosschain/keeper/observed.go
@@ -11,11 +11,7 @@ import (
 // GetLastObservedEventNonce returns the latest observed event nonce
 func (k Keeper) GetLastObservedEventNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	bytes := store.Get(types.LastObservedEventNonceKey)
-	if len(bytes) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(bytes)
+	return sdk.BigEndianToUint64(store.Get(types.LastObservedEventNonceKey))
 }
 
 // SetLastObservedEventNonce sets the latest observed event nonce

--- a/x/crosschain/keeper/oracle.go
+++ b/x/crosschain/keeper/oracle.go
@@ -226,9 +226,5 @@ func (k Keeper) SetLastOracleSlashBlockHeight(ctx sdk.Context, blockHeight uint6
 // GetLastOracleSlashBlockHeight returns the last proposal block height
 func (k Keeper) GetLastOracleSlashBlockHeight(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	data := store.Get(types.LastOracleSlashBlockHeight)
-	if len(data) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(data)
+	return sdk.BigEndianToUint64(store.Get(types.LastOracleSlashBlockHeight))
 }

--- a/x/crosschain/keeper/oracle_set.go
+++ b/x/crosschain/keeper/oracle_set.go
@@ -184,11 +184,7 @@ func (k Keeper) SetLatestOracleSetNonce(ctx sdk.Context, nonce uint64) {
 // GetLatestOracleSetNonce returns the latest oracleSet nonce
 func (k Keeper) GetLatestOracleSetNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	data := store.Get(types.LatestOracleSetNonce)
-	if len(data) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(data)
+	return sdk.BigEndianToUint64(store.Get(types.LatestOracleSetNonce))
 }
 
 // GetUnSlashedOracleSets returns all the unSlashed oracle sets in state

--- a/x/crosschain/keeper/oracle_set_confirm.go
+++ b/x/crosschain/keeper/oracle_set_confirm.go
@@ -65,9 +65,5 @@ func (k Keeper) SetLastSlashedOracleSetNonce(ctx sdk.Context, nonce uint64) {
 // GetLastSlashedOracleSetNonce returns the latest slashed oracleSet nonce
 func (k Keeper) GetLastSlashedOracleSetNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	data := store.Get(types.LastSlashedOracleSetNonce)
-	if len(data) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(data)
+	return sdk.BigEndianToUint64(store.Get(types.LastSlashedOracleSetNonce))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced efficiency of various methods related to event and oracle data retrieval by simplifying return statements and removing unnecessary checks.
  
- **Bug Fixes**
	- Streamlined logic in multiple methods to ensure consistent and faster data retrieval without altering output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->