### PR TITLE
fix: correct typo in interface name from 'BrideFeeQuoteKeeper' to 'BridgeFeeQuoteKeeper'

### DIFF
--- a/x/crosschain/keeper/keeper.go
+++ b/x/crosschain/keeper/keeper.go
@@ -28,7 +28,7 @@ type Keeper struct {
 	ibcTransferKeeper   types.IBCTransferKeeper
 	erc20Keeper         types.Erc20Keeper
 	evmKeeper           types.EVMKeeper
-	brideFeeQuoteKeeper types.BrideFeeQuoteKeeper
+	brideFeeQuoteKeeper types.BridgeFeeQuoteKeeper
 
 	authority    string
 	callbackFrom common.Address
@@ -38,7 +38,7 @@ type Keeper struct {
 func NewKeeper(cdc codec.BinaryCodec, moduleName string, storeKey storetypes.StoreKey,
 	stakingKeeper types.StakingKeeper, stakingMsgServer types.StakingMsgServer, distributionKeeper types.DistributionMsgServer,
 	bankKeeper types.BankKeeper, ibcTransferKeeper types.IBCTransferKeeper, erc20Keeper types.Erc20Keeper, ak types.AccountKeeper,
-	evmKeeper types.EVMKeeper, brideFeeQuoteKeeper types.BrideFeeQuoteKeeper, authority string,
+	evmKeeper types.EVMKeeper, brideFeeQuoteKeeper types.BridgeFeeQuoteKeeper, authority string,
 ) Keeper {
 	if addr := ak.GetModuleAddress(moduleName); addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", moduleName))

--- a/x/crosschain/mock/expected_keepers_mocks.go
+++ b/x/crosschain/mock/expected_keepers_mocks.go
@@ -754,31 +754,31 @@ func (mr *MockAccountKeeperMockRecorder) SetAccount(ctx, acc any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAccount", reflect.TypeOf((*MockAccountKeeper)(nil).SetAccount), ctx, acc)
 }
 
-// MockBrideFeeQuoteKeeper is a mock of BrideFeeQuoteKeeper interface.
-type MockBrideFeeQuoteKeeper struct {
+// MockBridgeFeeQuoteKeeper is a mock of BridgeFeeQuoteKeeper interface.
+type MockBridgeFeeQuoteKeeper struct {
 	ctrl     *gomock.Controller
-	recorder *MockBrideFeeQuoteKeeperMockRecorder
+	recorder *MockBridgeFeeQuoteKeeperMockRecorder
 }
 
-// MockBrideFeeQuoteKeeperMockRecorder is the mock recorder for MockBrideFeeQuoteKeeper.
-type MockBrideFeeQuoteKeeperMockRecorder struct {
-	mock *MockBrideFeeQuoteKeeper
+// MockBridgeFeeQuoteKeeperMockRecorder is the mock recorder for MockBridgeFeeQuoteKeeper.
+type MockBridgeFeeQuoteKeeperMockRecorder struct {
+	mock *MockBridgeFeeQuoteKeeper
 }
 
-// NewMockBrideFeeQuoteKeeper creates a new mock instance.
-func NewMockBrideFeeQuoteKeeper(ctrl *gomock.Controller) *MockBrideFeeQuoteKeeper {
-	mock := &MockBrideFeeQuoteKeeper{ctrl: ctrl}
-	mock.recorder = &MockBrideFeeQuoteKeeperMockRecorder{mock}
+// NewMockBridgeFeeQuoteKeeper creates a new mock instance.
+func NewMockBridgeFeeQuoteKeeper(ctrl *gomock.Controller) *MockBridgeFeeQuoteKeeper {
+	mock := &MockBridgeFeeQuoteKeeper{ctrl: ctrl}
+	mock.recorder = &MockBridgeFeeQuoteKeeperMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockBrideFeeQuoteKeeper) EXPECT() *MockBrideFeeQuoteKeeperMockRecorder {
+func (m *MockBridgeFeeQuoteKeeper) EXPECT() *MockBridgeFeeQuoteKeeperMockRecorder {
 	return m.recorder
 }
 
 // GetQuotesByToken mocks base method.
-func (m *MockBrideFeeQuoteKeeper) GetQuotesByToken(ctx context.Context, chainName, denom string) ([]contract.IBridgeFeeQuoteQuoteInfo, error) {
+func (m *MockBridgeFeeQuoteKeeper) GetQuotesByToken(ctx context.Context, chainName, denom string) ([]contract.IBridgeFeeQuoteQuoteInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetQuotesByToken", ctx, chainName, denom)
 	ret0, _ := ret[0].([]contract.IBridgeFeeQuoteQuoteInfo)
@@ -787,7 +787,7 @@ func (m *MockBrideFeeQuoteKeeper) GetQuotesByToken(ctx context.Context, chainNam
 }
 
 // GetQuotesByToken indicates an expected call of GetQuotesByToken.
-func (mr *MockBrideFeeQuoteKeeperMockRecorder) GetQuotesByToken(ctx, chainName, denom any) *gomock.Call {
+func (mr *MockBridgeFeeQuoteKeeperMockRecorder) GetQuotesByToken(ctx, chainName, denom any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQuotesByToken", reflect.TypeOf((*MockBrideFeeQuoteKeeper)(nil).GetQuotesByToken), ctx, chainName, denom)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQuotesByToken", reflect.TypeOf((*MockBridgeFeeQuoteKeeper)(nil).GetQuotesByToken), ctx, chainName, denom)
 }

--- a/x/crosschain/types/expected_keepers.go
+++ b/x/crosschain/types/expected_keepers.go
@@ -87,6 +87,6 @@ type AccountKeeper interface {
 	GetModuleAccount(ctx context.Context, moduleName string) sdk.ModuleAccountI
 }
 
-type BrideFeeQuoteKeeper interface {
+type BridgeFeeQuoteKeeper interface {
 	GetQuotesByToken(ctx context.Context, chainName, denom string) ([]contract.IBridgeFeeQuoteQuoteInfo, error)
 }


### PR DESCRIPTION
Ref: https://github.com/PundiAi/fx-core/pull/788