### PR TITLE
chore: fix some struct field name in comment

### DIFF
--- a/ante/disable_msg.go
+++ b/ante/disable_msg.go
@@ -7,7 +7,7 @@ import (
 
 type DisableMsgDecorator struct {
 	govKeeper Govkeeper
-	// disabledMsgs is a set that contains type urls of unauthorized msgs.
+	// disabledMsgTypes is a set that contains type urls of unauthorized msgs.
 	disabledMsgTypes []string
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -40,7 +40,7 @@ func DefaultBypassMinFee() BypassMinFee {
 type Config struct {
 	config.Config `mapstructure:",squash"`
 
-	// BypassMinFeeMsgTypes defines custom that will bypass minimum fee checks during CheckTx.
+	// BypassMinFee defines custom that will bypass minimum fee checks during CheckTx.
 	BypassMinFee BypassMinFee `mapstructure:"bypass-min-fee"`
 
 	EVM     ethermintconfig.EVMConfig     `mapstructure:"evm"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation Updates**
	- Improved clarity of comments for `disabledMsgTypes` in the `DisableMsgDecorator` struct.
	- Enhanced documentation for the `BypassMinFee` field in the `Config` struct. 

These changes aim to provide better understanding and clarity for users regarding message handling and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->