### PR TITLE
chore: rename GetBaseDenomByErc20 to GetERC20TokenByAddr

### DIFF
--- a/precompiles/crosschain/keeper.go
+++ b/precompiles/crosschain/keeper.go
@@ -6,28 +6,28 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	"github.com/pundiai/fx-core/v8/contract"
-	types2 "github.com/pundiai/fx-core/v8/precompiles/types"
+	"github.com/pundiai/fx-core/v8/precompiles/types"
 	fxtypes "github.com/pundiai/fx-core/v8/types"
 	erc20types "github.com/pundiai/fx-core/v8/x/erc20/types"
 )
 
 type Keeper struct {
 	router     *Router
-	bankKeeper types2.BankKeeper
+	bankKeeper types.BankKeeper
 }
 
-func (c *Keeper) EvmTokenToBaseCoin(ctx sdk.Context, evm *vm.EVM, crosschainKeeper types2.CrosschainKeeper, holder, tokenAddr common.Address, amount *big.Int) (sdk.Coin, error) {
-	erc20Token, err := crosschainKeeper.GetBaseDenomByErc20(ctx, tokenAddr)
+func (c *Keeper) EvmTokenToBaseCoin(ctx sdk.Context, evm *vm.EVM, crosschainKeeper types.CrosschainKeeper, holder, tokenAddr common.Address, amount *big.Int) (sdk.Coin, error) {
+	erc20Token, err := crosschainKeeper.GetERC20TokenByAddr(ctx, tokenAddr)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
 	baseCoin := sdk.NewCoin(erc20Token.Denom, sdkmath.NewIntFromBigInt(amount))
-	erc20ModuleAddress := common.BytesToAddress(types.NewModuleAddress(erc20types.ModuleName))
+	erc20ModuleAddress := common.BytesToAddress(authtypes.NewModuleAddress(erc20types.ModuleName))
 
 	erc20Call := contract.NewERC20Call(evm, erc20ModuleAddress, tokenAddr, 0)
 	if erc20Token.IsNativeCoin() {

--- a/precompiles/types/expected_keepers.go
+++ b/precompiles/types/expected_keepers.go
@@ -31,7 +31,7 @@ type CrosschainKeeper interface {
 	BridgeCoinSupply(ctx context.Context, token, target string) (sdk.Coin, error)
 	CrosschainBaseCoin(ctx sdk.Context, from sdk.AccAddress, receipt string, amount, fee sdk.Coin, fxTarget *crosschaintypes.FxTarget, memo string, originToken bool) error
 	BridgeCallBaseCoin(ctx sdk.Context, from, refund, to common.Address, coins sdk.Coins, data, memo []byte, quoteId *big.Int, fxTarget *crosschaintypes.FxTarget, originTokenAmount sdkmath.Int) (uint64, error)
-	GetBaseDenomByErc20(ctx sdk.Context, erc20Addr common.Address) (erc20types.ERC20Token, error)
+	GetERC20TokenByAddr(ctx sdk.Context, erc20Addr common.Address) (erc20types.ERC20Token, error)
 
 	HasOracleAddrByExternalAddr(ctx sdk.Context, externalAddress string) bool
 	GetOracleAddrByExternalAddr(ctx sdk.Context, externalAddress string) (sdk.AccAddress, bool)

--- a/x/crosschain/keeper/bridge_token.go
+++ b/x/crosschain/keeper/bridge_token.go
@@ -66,7 +66,7 @@ func (k Keeper) BridgeCoinSupply(ctx context.Context, token, target string) (sdk
 	return supply, nil
 }
 
-func (k Keeper) GetBaseDenomByErc20(ctx sdk.Context, erc20Addr common.Address) (erc20types.ERC20Token, error) {
+func (k Keeper) GetERC20TokenByAddr(ctx sdk.Context, erc20Addr common.Address) (erc20types.ERC20Token, error) {
 	baseDenom, err := k.erc20Keeper.GetBaseDenom(ctx, erc20Addr.String())
 	if err != nil {
 		return erc20types.ERC20Token{}, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated method names for clarity and alignment with functionality, including `GetBaseDenomByErc20` to `GetERC20TokenByAddr`.
- **Bug Fixes**
	- Improved type references in method signatures and struct fields to enhance code clarity.
- **Refactor**
	- Streamlined import statements and removed unnecessary type aliases for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->