### PR TITLE
fix(x/crosschain):  resolve failure in UnpackInterfacesMessage

### DIFF
--- a/app/interface_registry.json
+++ b/app/interface_registry.json
@@ -17,8 +17,6 @@
     "cosmos.vesting.v1beta1.VestingAccount",
     "ethermint.evm.v1.TxData",
     "fx.ibc.applications.transfer.v1.MemoPacket",
-    "gravity.v1beta1.Confirm",
-    "gravity.v1beta1.ExternalClaim",
     "ibc.core.channel.v1.ChannelI",
     "ibc.core.channel.v1.CounterpartyChannelI",
     "ibc.core.channel.v1.PacketI",

--- a/x/crosschain/types/codec.go
+++ b/x/crosschain/types/codec.go
@@ -40,8 +40,13 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		&MsgConfirm{},
 	)
 
-	registry.RegisterInterface(
-		"gravity.v1beta1.ExternalClaim",
+	registry.RegisterImplementations(
+		(*govv1betal.Content)(nil),
+		&InitCrossChainParamsProposal{},
+		&UpdateChainOraclesProposal{},
+	)
+
+	registry.RegisterImplementations(
 		(*ExternalClaim)(nil),
 		&MsgSendToExternalClaim{},
 		&MsgSendToFxClaim{},
@@ -51,18 +56,11 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		&MsgBridgeCallResultClaim{},
 	)
 
-	registry.RegisterInterface(
-		"gravity.v1beta1.Confirm",
+	registry.RegisterImplementations(
 		(*Confirm)(nil),
 		&MsgConfirmBatch{},
 		&MsgOracleSetConfirm{},
 		&MsgBridgeCallConfirm{},
-	)
-
-	registry.RegisterImplementations(
-		(*govv1betal.Content)(nil),
-		&InitCrossChainParamsProposal{},
-		&UpdateChainOraclesProposal{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/crosschain/types/msgs.go
+++ b/x/crosschain/types/msgs.go
@@ -9,6 +9,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -67,7 +68,10 @@ var (
 	_ sdk.Msg = &MsgUpdateParams{}
 	_ sdk.Msg = &MsgUpdateChainOracles{}
 	_ sdk.Msg = &MsgClaim{}
+	_ sdk.Msg = &MsgConfirm{}
 )
+
+var _ codectypes.UnpackInterfacesMessage = &MsgClaim{}
 
 func (m *MsgBondedOracle) ValidateBasic() (err error) {
 	if _, ok := externalAddressRouter[m.ChainName]; !ok {
@@ -308,6 +312,11 @@ func (m *MsgClaim) GetSigners() []sdk.AccAddress {
 		panic(sdkerrors.ErrInvalidRequest.Wrapf("expected claim type %T, got %T", new(ExternalClaim), m.Claim.GetCachedValue()))
 	}
 	return []sdk.AccAddress{claim.GetClaimer()}
+}
+
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (m MsgClaim) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	return sdktx.UnpackInterfaces(unpacker, []*codectypes.Any{m.Claim})
 }
 
 func (m *MsgSendToFxClaim) GetType() ClaimType {
@@ -676,4 +685,9 @@ func (m *MsgUpdateChainOracles) ValidateBasic() error {
 		oraclesMap[addr] = true
 	}
 	return nil
+}
+
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (m MsgConfirm) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	return sdktx.UnpackInterfaces(unpacker, []*codectypes.Any{m.Confirm})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Interface Changes**
	- Removed two interfaces: `gravity.v1beta1.Confirm` and `gravity.v1beta1.ExternalClaim`
	- Updated interface registrations for cross-chain operations

- **Message Handling**
	- Enhanced message types with new interface unpacking methods
	- Added support for dynamic message type handling in cross-chain transactions

- **Code Maintenance**
	- Streamlined interface and message type implementations
	- Improved modularity for cross-chain interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->