### PR TITLE
fix: remove deprecated tokens from testnet

### DIFF
--- a/app/upgrade_test.go
+++ b/app/upgrade_test.go
@@ -190,13 +190,13 @@ func checkMigrateBalance(t *testing.T, ctx sdk.Context, myApp *app.App, bdd Befo
 	t.Helper()
 
 	newAccountBalance, newModuleBalance := allBalances(ctx, myApp)
-	require.Equal(t, len(newAccountBalance), len(bdd.AccountBalances))
+	require.GreaterOrEqual(t, len(bdd.AccountBalances), len(newAccountBalance))
 
 	// check address balance
 	checkAccountBalance(t, ctx, myApp, bdd.AccountBalances, newAccountBalance)
 
 	for moduleName, coins := range newModuleBalance {
-		if moduleName == erc20types.ModuleName && ctx.ChainID() == fxtypes.MainnetChainId {
+		if moduleName == erc20types.ModuleName {
 			for _, coin := range coins {
 				found, err := myApp.Erc20Keeper.HasToken(ctx, coin.Denom)
 				require.NoError(t, err)
@@ -228,7 +228,7 @@ func checkAccountBalance(t *testing.T, ctx sdk.Context, myApp *app.App, accountB
 
 			if !foundToken && !foundMD {
 				balance := myApp.BankKeeper.GetBalance(ctx, addr, coin.Denom)
-				require.Equal(t, balance.Amount, coin.Amount)
+				require.True(t, balance.Amount.Equal(coin.Amount) || balance.Amount.IsZero())
 				continue
 			}
 

--- a/app/upgrades/v8/constants.go
+++ b/app/upgrades/v8/constants.go
@@ -59,3 +59,8 @@ func getContractOwner(ctx sdk.Context) common.Address {
 	}
 	return common.HexToAddress(mainnetOwnerAddress)
 }
+
+const (
+	pundixSymbol = "PUNDIX"
+	purseSymbol  = "PURSE"
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new constants for token symbols: PUNDIX and PURSE
	- Introduced functions to remove deprecated testnet denominations and coins

- **Improvements**
	- Enhanced upgrade process error handling
	- Refined balance and metadata migration logic
	- Updated type consistency for account handling

- **Bug Fixes**
	- Improved validation for account balances during upgrade process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->