### PR TITLE
chore(gosec): exclude rule G304 from security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,7 +47,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
-          args: "-exclude=G101,G107,G115 -no-fail -fmt sarif -out results.sarif ./..."
+          args: "-exclude=G101,G107,G115,G304 -no-fail -fmt sarif -out results.sarif ./..."
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub security workflow configuration
	- Modified Gosec security scanner settings to exclude additional security check

<!-- end of auto-generated comment: release notes by coderabbit.ai -->