### PR TITLE
chore(docker): upgrade golang version to 1.23.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19 as builder
+FROM golang:1.23.1-alpine3.19 as builder
 
 RUN apk add --no-cache git build-base linux-headers binutils-gold
 

--- a/cosmovisor.Dockerfile
+++ b/cosmovisor.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19 as builder
+FROM golang:1.23.1-alpine3.19 as builder
 
 RUN apk add --no-cache git build-base linux-headers binutils-gold
 

--- a/cosmovisor_lite.Dockerfile
+++ b/cosmovisor_lite.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19 as builder
+FROM golang:1.23.1-alpine3.19 as builder
 
 RUN apk add --no-cache git build-base linux-headers binutils-gold
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated base Docker images from Go 1.23.0 to Go 1.23.1 across multiple Dockerfiles
	- Upgraded build environment for Dockerfile, cosmovisor.Dockerfile, and cosmovisor_lite.Dockerfile

<!-- end of auto-generated comment: release notes by coderabbit.ai -->