### PR TITLE
chore(cosmovisor): add previous version binaries to upgrades

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     paths:
       - 'Dockerfile'
-      - 'cosmovisor.Dockerfile'
-      - 'cosmovisor_lite.Dockerfile'
+      - 'Dockerfile.cosmovisor'
+      - 'Dockerfile.cosmovisor-lite'
       - '.github/workflows/docker.yml'
 
 permissions:
@@ -50,8 +50,9 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
-  cosmovisor_lite:
+  cosmovisor-lite:
     runs-on: ubuntu-latest
+    needs: fxcore
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -80,13 +81,14 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./cosmovisor_lite.Dockerfile
+          file: ./Dockerfile.cosmovisor-lite
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
   cosmovisor:
     runs-on: ubuntu-latest
+    needs: fxcore
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -115,7 +117,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./cosmovisor.Dockerfile
+          file: ./Dockerfile.cosmovisor
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,13 +46,14 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
   cosmovisor-lite:
     runs-on: ubuntu-latest
     needs: fxcore
+    if: github.event_name == 'push'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -82,13 +83,14 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.cosmovisor-lite
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
   cosmovisor:
     runs-on: ubuntu-latest
     needs: fxcore
+    if: github.event_name == 'push'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -118,6 +120,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.cosmovisor
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.19 as builder
+FROM golang:1.23.1-alpine3.19 AS builder
 
 RUN apk add --no-cache git build-base linux-headers binutils-gold
 

--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -1,16 +1,12 @@
-FROM golang:1.23.1-alpine3.19 as builder
+FROM ghcr.io/pundiai/fxcorevisor:7.5.1 AS fxv7_5
+FROM ghcr.io/pundiai/fx-core:8.0.1-rc0 AS fxv8
+FROM --platform=$BUILDPLATFORM alpine:3.19 AS downloader
 
-RUN apk add --no-cache git build-base linux-headers binutils-gold
+ARG TARGETPLATFORM
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.6.0
-
-WORKDIR /app
-
-COPY . .
-
-RUN make build
-
-FROM ghcr.io/pundiai/fxcorevisor:7.5.1 as fxv7_5
+RUN ARCH=$(echo "$TARGETPLATFORM" | cut -d'/' -f2) && \
+    wget -c https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.7.0/cosmovisor-v1.7.0-linux-$ARCH.tar.gz && \
+    tar -zxvf cosmovisor-v1.7.0-linux-$ARCH.tar.gz
 
 FROM alpine:3.19
 
@@ -32,8 +28,9 @@ ENV PATH="/root/.fxcore/cosmovisor/current/bin:${PATH}"
 
 COPY --from=fxv7_5 /root/.fxcore/cosmovisor /root/.fxcore/cosmovisor
 
-COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
-COPY --from=builder /app/build/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.0.x/bin/fxcored
+COPY --from=fxv8 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.0.x/bin/fxcored
+
+COPY --from=downloader /cosmovisor /usr/bin/cosmovisor
 
 RUN cosmovisor init /root/.fxcore/cosmovisor/genesis/bin/fxcored
 

--- a/Dockerfile.cosmovisor
+++ b/Dockerfile.cosmovisor
@@ -1,12 +1,13 @@
 FROM ghcr.io/pundiai/fxcorevisor:7.5.1 AS fxv7_5
-FROM ghcr.io/pundiai/fx-core:8.0.1-rc0 AS fxv8
+FROM ghcr.io/pundiai/fx-core:8.0.0-rc0 AS fxv8
+FROM ghcr.io/pundiai/fx-core:8.1.0-rc1 AS fxv8_1
 FROM --platform=$BUILDPLATFORM alpine:3.19 AS downloader
 
 ARG TARGETPLATFORM
 
 RUN ARCH=$(echo "$TARGETPLATFORM" | cut -d'/' -f2) && \
-    wget -c https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.7.0/cosmovisor-v1.7.0-linux-$ARCH.tar.gz && \
-    tar -zxvf cosmovisor-v1.7.0-linux-$ARCH.tar.gz
+    wget -c https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.6.0/cosmovisor-v1.6.0-linux-$ARCH.tar.gz && \
+    tar -zxvf cosmovisor-v1.6.0-linux-$ARCH.tar.gz
 
 FROM alpine:3.19
 
@@ -29,6 +30,7 @@ ENV PATH="/root/.fxcore/cosmovisor/current/bin:${PATH}"
 COPY --from=fxv7_5 /root/.fxcore/cosmovisor /root/.fxcore/cosmovisor
 
 COPY --from=fxv8 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.0.x/bin/fxcored
+COPY --from=fxv8_1 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.1.x/bin/fxcored
 
 COPY --from=downloader /cosmovisor /usr/bin/cosmovisor
 

--- a/Dockerfile.cosmovisor-lite
+++ b/Dockerfile.cosmovisor-lite
@@ -1,16 +1,12 @@
-FROM golang:1.23.1-alpine3.19 as builder
+FROM ghcr.io/pundiai/fx-core:7.5.1 AS fxv7_5
+FROM ghcr.io/pundiai/fx-core:8.0.1-rc0 AS fxv8
+FROM --platform=$BUILDPLATFORM alpine:3.19 AS downloader
 
-RUN apk add --no-cache git build-base linux-headers binutils-gold
+ARG TARGETPLATFORM
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.6.0
-
-WORKDIR /app
-
-COPY . .
-
-RUN make build
-
-FROM ghcr.io/pundiai/fx-core:7.5.1 as fxv7_5
+RUN ARCH=$(echo "$TARGETPLATFORM" | cut -d'/' -f2) && \
+    wget -c https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.7.0/cosmovisor-v1.7.0-linux-$ARCH.tar.gz && \
+    tar -zxvf cosmovisor-v1.7.0-linux-$ARCH.tar.gz
 
 FROM alpine:3.19
 
@@ -31,9 +27,12 @@ ENV COSMOVISOR_COLOR_LOGS=true
 ENV PATH="/root/.fxcore/cosmovisor/current/bin:${PATH}"
 
 COPY --from=fxv7_5 /usr/bin/fxcored /root/.fxcore/cosmovisor/genesis/bin/fxcored
+RUN mkdir -p /root/.fxcore/cosmovisor/upgrades/v7.5.x/bin && \
+    ln -s /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.5.x/bin/fxcored
 
-COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
-COPY --from=builder /app/build/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.0.x/bin/fxcored
+COPY --from=fxv8 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.0.x/bin/fxcored
+
+COPY --from=downloader /cosmovisor /usr/bin/cosmovisor
 
 RUN cosmovisor init /root/.fxcore/cosmovisor/genesis/bin/fxcored
 

--- a/Dockerfile.cosmovisor-lite
+++ b/Dockerfile.cosmovisor-lite
@@ -1,12 +1,13 @@
 FROM ghcr.io/pundiai/fx-core:7.5.1 AS fxv7_5
-FROM ghcr.io/pundiai/fx-core:8.0.1-rc0 AS fxv8
+FROM ghcr.io/pundiai/fx-core:8.0.0-rc0 AS fxv8
+FROM ghcr.io/pundiai/fx-core:8.1.0-rc1 AS fxv8_1
 FROM --platform=$BUILDPLATFORM alpine:3.19 AS downloader
 
 ARG TARGETPLATFORM
 
 RUN ARCH=$(echo "$TARGETPLATFORM" | cut -d'/' -f2) && \
-    wget -c https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.7.0/cosmovisor-v1.7.0-linux-$ARCH.tar.gz && \
-    tar -zxvf cosmovisor-v1.7.0-linux-$ARCH.tar.gz
+    wget -c https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2Fv1.6.0/cosmovisor-v1.6.0-linux-$ARCH.tar.gz && \
+    tar -zxvf cosmovisor-v1.6.0-linux-$ARCH.tar.gz
 
 FROM alpine:3.19
 
@@ -31,6 +32,7 @@ RUN mkdir -p /root/.fxcore/cosmovisor/upgrades/v7.5.x/bin && \
     ln -s /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.5.x/bin/fxcored
 
 COPY --from=fxv8 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.0.x/bin/fxcored
+COPY --from=fxv8_1 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v8.1.x/bin/fxcored
 
 COPY --from=downloader /cosmovisor /usr/bin/cosmovisor
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for Docker image builds
	- Renamed Dockerfiles to follow consistent naming convention
	- Modified Dockerfile build processes for `cosmovisor` and `cosmovisor-lite`

- **New Features**
	- Introduced multi-stage Docker builds with pre-built base images
	- Added platform-specific binary downloads for `cosmovisor`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->