### PR TITLE
fix(x/erc20): show struct content in autocli query

### DIFF
--- a/scripts/linter.sh
+++ b/scripts/linter.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 patternLimits=(
-  "nolint:20"
+  "nolint:21"
   "#nosec:5"
   "CrossChain:4"
   "cross chain:0"

--- a/x/erc20/autocli.go
+++ b/x/erc20/autocli.go
@@ -1,0 +1,4 @@
+package erc20
+
+//nolint:revive // Importing api/fx/erc20/v1 to resolves the  auto cli not finding the proto.
+import _ "github.com/pundiai/fx-core/v8/api/fx/erc20/v1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated linter script to allow one additional occurrence of the "nolint" pattern
	- Added new package and import for ERC20 auto CLI functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->