### PR TITLE
fix(x/ibctransfer): correct channel validation in wrap sendPacket

### DIFF
--- a/x/ibc/middleware/keeper/relay.go
+++ b/x/ibc/middleware/keeper/relay.go
@@ -21,6 +21,7 @@ func (k Keeper) OnRecvPacketWithoutRouter(ctx sdk.Context, ibcModule porttypes.I
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
 
+	// Only the receiver is replaced with the fx address, which is compatible with the evm address
 	newPacketData := data.ToIBCPacketData()
 	newPacketData.Receiver = receiver.String()
 
@@ -31,7 +32,8 @@ func (k Keeper) OnRecvPacketWithoutRouter(ctx sdk.Context, ibcModule porttypes.I
 		return ack
 	}
 
-	if err = k.OnRecvPacket(zeroGasConfigCtx(ctx), newPacket, newPacketData); err != nil {
+	// Use the original package to handle ibc to evm
+	if err = k.OnRecvPacket(zeroGasConfigCtx(ctx), packet, data.ToIBCPacketData()); err != nil {
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
 

--- a/x/ibc/middleware/keeper/wrap_channel_keeper.go
+++ b/x/ibc/middleware/keeper/wrap_channel_keeper.go
@@ -37,7 +37,7 @@ func (k WarpChannelKeeper) SendPacket(
 		return k.Keeper.SendPacket(ctx, chanCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
 	}
 
-	if fxtypes.IsPundixChannel(sourceChannel, sourceChannel) && packetData.Denom == fxtypes.PundixWrapDenom {
+	if fxtypes.IsPundixChannel(sourcePort, sourceChannel) && packetData.Denom == fxtypes.PundixWrapDenom {
 		packetData.Denom = fxtypes.GetPundixUnWrapDenom(ctx.ChainID())
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Updated packet handling logic for IBC to EVM interactions
    - Modified channel packet sending conditions to correctly identify Pundix channels

The changes improve the reliability of packet routing and channel management in the IBC middleware, ensuring more accurate processing of cross-chain communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->