### PR TITLE
refactor: modify ApplyContract to return result even on EVM execution failure

### DIFF
--- a/x/evm/keeper/contract_code.go
+++ b/x/evm/keeper/contract_code.go
@@ -136,9 +136,5 @@ func (k *Keeper) ApplyContract(ctx context.Context, from, contract common.Addres
 	if err != nil {
 		return nil, err
 	}
-	resp, err := k.callEvm(sdk.UnwrapSDKContext(ctx), from, &contract, value, nonce, data, true)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return k.callEvm(sdk.UnwrapSDKContext(ctx), from, &contract, value, nonce, data, true)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the `ApplyContract` method's implementation by streamlining the return of the `callEvm` method result.

Note: The changes appear to be internal code optimization with no direct user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->