### PR TITLE
refactor(x/ibctransfer): convert osmosis FX to PUNDIAI

### DIFF
--- a/types/denom_wrap.go
+++ b/types/denom_wrap.go
@@ -1,26 +1,88 @@
 package types
 
+import (
+	"fmt"
+
+	sdkmath "cosmossdk.io/math"
+	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+)
+
 const (
 	PundixWrapDenom = "pundix"
 	PundixChannel   = "channel-0"
-	PundixPort      = "transfer"
 )
 
 const (
 	MainnetPundixUnWrapDenom = "eth0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38"
+	MainnetOsmosisChannel    = "channel-19"
 )
 
 const (
 	TestnetPundixUnWrapDenom = "eth0xd9EEd31F5731DfC3Ca18f09B487e200F50a6343B"
+	TestnetOsmosisChannel    = "channel-119"
 )
 
-func IsPundixChannel(port, channel string) bool {
-	return port == PundixPort && channel == PundixChannel
+var (
+	MainnetOnRecvWrap = map[string]string{
+		OnRecvDenomWrapKey(PundixChannel, MainnetPundixUnWrapDenom): PundixWrapDenom,
+		OnRecvDenomWrapKey(MainnetOsmosisChannel, FXDenom):          DefaultDenom,
+	}
+
+	MainnetSendPacketWrap = map[string]string{
+		SendPacketDenomWrapKey(PundixChannel, PundixWrapDenom): MainnetPundixUnWrapDenom,
+	}
+)
+
+var (
+	TestnetOnRecvWrap = map[string]string{
+		OnRecvDenomWrapKey(PundixChannel, TestnetPundixUnWrapDenom): PundixWrapDenom,
+		OnRecvDenomWrapKey(TestnetOsmosisChannel, FXDenom):          DefaultDenom,
+	}
+	TestnetSendPacketWrap = map[string]string{
+		SendPacketDenomWrapKey(PundixChannel, PundixWrapDenom): TestnetPundixUnWrapDenom,
+	}
+)
+
+func OnRecvDenomNeedWrap(chainId, channel, denom string) (bool, string) {
+	var needWrap bool
+	var wrapDenom string
+	denomWrapKey := OnRecvDenomWrapKey(channel, denom)
+	if chainId == MainnetChainId {
+		wrapDenom, needWrap = MainnetOnRecvWrap[denomWrapKey]
+	} else {
+		wrapDenom, needWrap = TestnetOnRecvWrap[denomWrapKey]
+	}
+	return needWrap, wrapDenom
 }
 
-func GetPundixUnWrapDenom(chainId string) string {
+func SendPacketDenomNeedWrap(chainId, channel, denom string) (bool, string) {
+	var needWrap bool
+	var wrapDenom string
+	denomWrapKey := SendPacketDenomWrapKey(channel, denom)
 	if chainId == MainnetChainId {
-		return MainnetPundixUnWrapDenom
+		wrapDenom, needWrap = MainnetSendPacketWrap[denomWrapKey]
+	} else {
+		wrapDenom, needWrap = TestnetSendPacketWrap[denomWrapKey]
 	}
-	return TestnetPundixUnWrapDenom
+	return needWrap, wrapDenom
+}
+
+func SendPacketDenomWrapKey(sourceChannel, denonm string) string {
+	return fmt.Sprintf("%s:%s", sourceChannel, denonm)
+}
+
+func OnRecvDenomWrapKey(destChannel, denonm string) string {
+	return fmt.Sprintf("%s:%s", destChannel, denonm)
+}
+
+func OnRecvAmountCovert(wrapDenom, amountStr string) (string, error) {
+	if wrapDenom != DefaultDenom {
+		return amountStr, nil
+	}
+
+	amount, ok := sdkmath.NewIntFromString(amountStr)
+	if !ok {
+		return amountStr, transfertypes.ErrInvalidAmount.Wrapf("unable to parse transfer amount (%s) into sdkmath.Int", amountStr)
+	}
+	return SwapAmount(amount).String(), nil
 }

--- a/x/ibc/middleware/ibc_middleware.go
+++ b/x/ibc/middleware/ibc_middleware.go
@@ -58,8 +58,14 @@ func UnMarshalPacket(chainID string, packet channeltypes.Packet) (types.Fungible
 		data.Fee = sdkmath.ZeroInt().String()
 	}
 
-	if fxtypes.IsPundixChannel(packet.GetDestPort(), packet.GetDestChannel()) && data.Denom == fxtypes.GetPundixUnWrapDenom(chainID) {
-		data.Denom = fxtypes.PundixWrapDenom
+	needWrap, wrapDenom := fxtypes.OnRecvDenomNeedWrap(chainID, packet.GetDestChannel(), data.Denom)
+	if needWrap {
+		data.Denom = wrapDenom
+		newAmount, err := fxtypes.OnRecvAmountCovert(wrapDenom, data.Amount)
+		if err != nil {
+			return data, err
+		}
+		data.Amount = newAmount
 	}
 
 	return data, data.ValidateBasic()

--- a/x/ibc/middleware/keeper/wrap_channel_keeper.go
+++ b/x/ibc/middleware/keeper/wrap_channel_keeper.go
@@ -37,8 +37,9 @@ func (k WarpChannelKeeper) SendPacket(
 		return k.Keeper.SendPacket(ctx, chanCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
 	}
 
-	if fxtypes.IsPundixChannel(sourcePort, sourceChannel) && packetData.Denom == fxtypes.PundixWrapDenom {
-		packetData.Denom = fxtypes.GetPundixUnWrapDenom(ctx.ChainID())
+	needWrap, wrapDenom := fxtypes.SendPacketDenomNeedWrap(ctx.ChainID(), sourceChannel, packetData.Denom)
+	if needWrap {
+		packetData.Denom = wrapDenom
 	}
 
 	return k.Keeper.SendPacket(ctx, chanCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, packetData.GetBytes())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced denomination wrapping functionality for mainnet and testnet scenarios
  - Improved token denomination handling in IBC middleware

- **Improvements**
  - More flexible and generalized approach to handling token denominations
  - Added support for dynamic denomination wrapping based on chain ID and channel
  - Introduced new utility functions for denomination wrap key generation and amount conversion

- **Changes**
  - Removed specific Pundix channel-related logic
  - Updated IBC middleware to support more generic denomination wrapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->