### PR TITLE
feat: update cosmos gas price to 5*1e9

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -330,7 +330,7 @@ func (suite *rpcTestSuite) TestClient_Query() {
 				sdk.Coins{
 					sdk.Coin{
 						Denom:  fxtypes.DefaultDenom,
-						Amount: sdkmath.NewInt(4).MulRaw(1e12),
+						Amount: sdkmath.NewInt(5).MulRaw(1e9),
 					},
 				},
 				nil,
@@ -375,7 +375,7 @@ func (suite *rpcTestSuite) TestClient_Query() {
 			wantRes: []interface{}{
 				sdk.Coin{
 					Denom:  fxtypes.DefaultDenom,
-					Amount: sdkmath.NewInt(488999).MulRaw(1e18),
+					Amount: sdkmath.NewInt(48899999875).MulRaw(1e13),
 				},
 				nil,
 			},
@@ -398,7 +398,7 @@ func (suite *rpcTestSuite) TestClient_Query() {
 				sdk.Coins{
 					sdk.Coin{
 						Denom:  fxtypes.DefaultDenom,
-						Amount: sdkmath.NewInt(488999).MulRaw(1e18),
+						Amount: sdkmath.NewInt(48899999875).MulRaw(1e13),
 					},
 				},
 				nil,

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	fxcfg "github.com/pundiai/fx-core/v8/server/config"
+	fxtypes "github.com/pundiai/fx-core/v8/types"
 )
 
 const (
@@ -52,6 +53,7 @@ func updateConfig(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	appConfig.MinGasPrices = fxtypes.GetDefGasPrice().String()
 	appConfig.EVM.MaxTxGasWanted = 0
 
 	fileName = filepath.Join(rootDir, "config", appFileName)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fxcfg "github.com/pundiai/fx-core/v8/server/config"
+	fxtypes "github.com/pundiai/fx-core/v8/types"
 )
 
 func Test_updateCfgCmd(t *testing.T) {
@@ -98,7 +99,7 @@ func TestPublicAppConfig(t *testing.T) {
 	appConfig.Pruning = pruningtypes.PruningOptionCustom
 	appConfig.PruningKeepRecent = "20000"
 	appConfig.PruningInterval = "10"
-	appConfig.MinGasPrices = "4000000000000FX"
+	appConfig.MinGasPrices = fxtypes.GetDefGasPrice().String()
 	appConfig.IAVLDisableFastNode = true
 	appConfig.Telemetry.EnableServiceLabel = true
 	appConfig.Telemetry.Enabled = true

--- a/public/mainnet/app.toml
+++ b/public/mainnet/app.toml
@@ -8,7 +8,7 @@
 # The minimum gas prices a validator is willing to accept for processing a
 # transaction. A transaction's fees must meet the minimum of any denomination
 # specified in this config (e.g. 0.25token1,0.0001token2).
-minimum-gas-prices = "4000000000000FX"
+minimum-gas-prices = "5000000000apundiai"
 
 # The maximum gas a query coming over rest/grpc may consume.
 # If this is set to zero, the query can consume an unbounded amount of gas.

--- a/public/testnet/app.toml
+++ b/public/testnet/app.toml
@@ -8,7 +8,7 @@
 # The minimum gas prices a validator is willing to accept for processing a
 # transaction. A transaction's fees must meet the minimum of any denomination
 # specified in this config (e.g. 0.25token1,0.0001token2).
-minimum-gas-prices = "4000000000000FX"
+minimum-gas-prices = "5000000000apundiai"
 
 # The maximum gas a query coming over rest/grpc may consume.
 # If this is set to zero, the query can consume an unbounded amount of gas.

--- a/server/config/data/app.json
+++ b/server/config/data/app.json
@@ -66,7 +66,7 @@
     "max-txs": -1
   },
   "min-retain-blocks": 0,
-  "minimum-gas-prices": "4000000000000apundiai",
+  "minimum-gas-prices": "5000000000apundiai",
   "pruning": "default",
   "pruning-interval": "0",
   "pruning-keep-recent": "0",

--- a/types/constant.go
+++ b/types/constant.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func GetDefGasPrice() sdk.Coin {
-	return sdk.NewCoin(DefaultDenom, sdkmath.NewInt(4_000).MulRaw(1e9))
+	return sdk.NewCoin(DefaultDenom, sdkmath.NewInt(5).MulRaw(1e9))
 }
 
 func GetDefaultNodeHome() string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Configuration Updates**
  - Updated minimum gas prices across mainnet, testnet, and server configurations
  - Changed default gas price from 4,000 to 5 for transaction processing

- **Testing**
  - Updated test cases to reflect new gas price and balance calculations
  - Adjusted expected values in client and configuration tests

- **System Changes**
  - Modified default gas price calculation in core types
  - Dynamically retrieve default gas price in configuration management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->