### PR TITLE
feat(x/ibctransfer): wrap FX token to DefaultDenom on OnRecvPacket is the Pundix Chain

### DIFF
--- a/types/denom_wrap.go
+++ b/types/denom_wrap.go
@@ -26,6 +26,7 @@ var (
 	MainnetOnRecvWrap = map[string]string{
 		OnRecvDenomWrapKey(PundixChannel, MainnetPundixUnWrapDenom): PundixWrapDenom,
 		OnRecvDenomWrapKey(MainnetOsmosisChannel, FXDenom):          DefaultDenom,
+		OnRecvDenomWrapKey(PundixChannel, FXDenom):                  DefaultDenom,
 	}
 
 	MainnetSendPacketWrap = map[string]string{
@@ -37,6 +38,7 @@ var (
 	TestnetOnRecvWrap = map[string]string{
 		OnRecvDenomWrapKey(PundixChannel, TestnetPundixUnWrapDenom): PundixWrapDenom,
 		OnRecvDenomWrapKey(TestnetOsmosisChannel, FXDenom):          DefaultDenom,
+		OnRecvDenomWrapKey(PundixChannel, FXDenom):                  DefaultDenom,
 	}
 	TestnetSendPacketWrap = map[string]string{
 		SendPacketDenomWrapKey(PundixChannel, PundixWrapDenom): TestnetPundixUnWrapDenom,

--- a/types/denom_wrap_test.go
+++ b/types/denom_wrap_test.go
@@ -1,0 +1,130 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	tmrand "github.com/cometbft/cometbft/libs/rand"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OnRecvDenomNeedWrap(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chainId   string
+		channel   string
+		denom     string
+		expected  bool
+		wrapDenom string
+	}{
+		{
+			name:      "mainnet ethPundix to pundix",
+			chainId:   MainnetChainId,
+			channel:   PundixChannel,
+			denom:     MainnetPundixUnWrapDenom,
+			expected:  true,
+			wrapDenom: PundixWrapDenom,
+		},
+		{
+			name:      "mainnet osmosis FX to DefaultDenom",
+			chainId:   MainnetChainId,
+			channel:   MainnetOsmosisChannel,
+			denom:     FXDenom,
+			expected:  true,
+			wrapDenom: DefaultDenom,
+		},
+		{
+			name:      "mainnet pundix FX to DefaultDenom",
+			chainId:   MainnetChainId,
+			channel:   PundixChannel,
+			denom:     FXDenom,
+			expected:  true,
+			wrapDenom: DefaultDenom,
+		},
+		{
+			name:      "testnet eth0xpundix to pundix",
+			chainId:   TestnetChainId,
+			channel:   PundixChannel,
+			denom:     TestnetPundixUnWrapDenom,
+			expected:  true,
+			wrapDenom: PundixWrapDenom,
+		},
+		{
+			name:      "testnet osmosis FX to DefaultDenom",
+			chainId:   TestnetChainId,
+			channel:   TestnetOsmosisChannel,
+			denom:     FXDenom,
+			expected:  true,
+			wrapDenom: DefaultDenom,
+		},
+		{
+			name:      "testnet pundix FX to DefaultDenom",
+			chainId:   TestnetChainId,
+			channel:   PundixChannel,
+			denom:     FXDenom,
+			expected:  true,
+			wrapDenom: DefaultDenom,
+		},
+		{
+			name:      "no need wrap",
+			chainId:   MainnetChainId,
+			channel:   PundixChannel,
+			denom:     strings.ToLower(tmrand.Str(6)),
+			expected:  false,
+			wrapDenom: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			needWrap, wrapDenom := OnRecvDenomNeedWrap(tc.chainId, tc.channel, tc.denom)
+			require.Equal(t, tc.expected, needWrap)
+			require.Equal(t, tc.wrapDenom, wrapDenom)
+		})
+	}
+}
+
+func Test_SendPacketDenomNeedWrap(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chainId   string
+		channel   string
+		denom     string
+		expected  bool
+		wrapDenom string
+	}{
+		{
+			name:      "mainnet pundix to ethPundix",
+			chainId:   MainnetChainId,
+			channel:   PundixChannel,
+			denom:     PundixWrapDenom,
+			expected:  true,
+			wrapDenom: MainnetPundixUnWrapDenom,
+		},
+		{
+			name:      "testnet pundix to ethPundix",
+			chainId:   TestnetChainId,
+			channel:   PundixChannel,
+			denom:     PundixWrapDenom,
+			expected:  true,
+			wrapDenom: TestnetPundixUnWrapDenom,
+		},
+		{
+			name:      "no need wrap",
+			chainId:   MainnetChainId,
+			channel:   PundixChannel,
+			denom:     strings.ToLower(tmrand.Str(6)),
+			expected:  false,
+			wrapDenom: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			needWrap, wrapDenom := SendPacketDenomNeedWrap(tc.chainId, tc.channel, tc.denom)
+			require.Equal(t, tc.expected, needWrap)
+			require.Equal(t, tc.wrapDenom, wrapDenom)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new denomination wrapping configurations for mainnet and testnet.

- **Tests**
	- Introduced comprehensive test coverage for denomination wrapping logic, including scenarios for receiving and sending packets across different networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->