### PR TITLE
refactor: update oracle delegate quantity and currency

### DIFF
--- a/app/genesis.json
+++ b/app/genesis.json
@@ -13,7 +13,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -70,7 +70,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -146,7 +146,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -226,7 +226,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -403,7 +403,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -462,7 +462,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -507,7 +507,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",
@@ -588,7 +588,7 @@
       "oracles": [],
       "delegate_threshold": {
         "denom": "apundiai",
-        "amount": "10000000000000000000000"
+        "amount": "100000000000000000000"
       },
       "delegate_multiple": "10",
       "bridge_call_timeout": "604800000",

--- a/x/crosschain/keeper/abci_test.go
+++ b/x/crosschain/keeper/abci_test.go
@@ -23,7 +23,7 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
 			ValidatorAddress: suite.ValAddr[i].String(),
-			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
+			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(100).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
@@ -37,7 +37,7 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 		suite.Require().EqualValues(i+1, len(oracleSets))
 
 		power := suite.Keeper().GetLastTotalPower(suite.Ctx)
-		expectPower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(int64(i + 1))).Quo(sdk.DefaultPowerReduction)
+		expectPower := sdkmath.NewInt(100).MulRaw(1e18).Mul(sdkmath.NewInt(int64(i + 1))).Quo(sdk.DefaultPowerReduction)
 		suite.Require().True(expectPower.Equal(power))
 	}
 
@@ -102,13 +102,13 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 
 	suite.Require().ErrorIs(types.ErrInvalid, err)
 
-	expectTotalPower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(10)).Quo(sdk.DefaultPowerReduction)
+	expectTotalPower := sdkmath.NewInt(100).MulRaw(1e18).Mul(sdkmath.NewInt(10)).Quo(sdk.DefaultPowerReduction)
 	actualTotalPower := suite.Keeper().GetLastTotalPower(suite.Ctx)
 	suite.Require().True(expectTotalPower.Equal(actualTotalPower))
 
 	expectMaxChangePower := types.AttestationProposalOracleChangePowerThreshold.Mul(expectTotalPower).Quo(sdkmath.NewInt(100))
 
-	expectDeletePower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(3)).Quo(sdk.DefaultPowerReduction)
+	expectDeletePower := sdkmath.NewInt(100).MulRaw(1e18).Mul(sdkmath.NewInt(3)).Quo(sdk.DefaultPowerReduction)
 	suite.Require().EqualValues(fmt.Sprintf("max change power, maxChangePowerThreshold: %s, deleteTotalPower: %s: %s", expectMaxChangePower.String(), expectDeletePower.String(), types.ErrInvalid), err.Error())
 
 	var newOracleList2 []string
@@ -133,7 +133,7 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
 			ValidatorAddress: suite.ValAddr[i].String(),
-			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
+			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(100).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		_, err := suite.MsgServer().BondedOracle(suite.Ctx, msgBondedOracle)
@@ -145,7 +145,7 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 		suite.Require().EqualValues(i+1, len(oracleSets))
 
 		power := suite.Keeper().GetLastTotalPower(suite.Ctx)
-		expectPower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(int64(i + 1))).Quo(sdk.DefaultPowerReduction)
+		expectPower := sdkmath.NewInt(100).MulRaw(1e18).Mul(sdkmath.NewInt(int64(i + 1))).Quo(sdk.DefaultPowerReduction)
 		suite.Require().True(expectPower.Equal(power))
 	}
 
@@ -324,7 +324,7 @@ func (suite *KeeperTestSuite) TestOracleDelete() {
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
 			ValidatorAddress: suite.ValAddr[i].String(),
-			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
+			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(100).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
@@ -356,7 +356,7 @@ func (suite *KeeperTestSuite) TestOracleDelete() {
 	suite.Require().EqualValues(bridger.String(), oracleData.BridgerAddress)
 	suite.Require().EqualValues(externalAddress, oracleData.ExternalAddress)
 
-	suite.Require().True(sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Equal(oracleData.DelegateAmount))
+	suite.Require().True(sdkmath.NewInt(100).MulRaw(1e18).Equal(oracleData.DelegateAmount))
 
 	newOracleAddressList := make([]string, 0, len(suite.oracleAddrs)-1)
 	for _, address := range suite.oracleAddrs[1:] {
@@ -391,7 +391,7 @@ func (suite *KeeperTestSuite) TestOracleSetSlash() {
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
 			ValidatorAddress: suite.ValAddr[i].String(),
-			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
+			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(100).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
@@ -449,7 +449,7 @@ func (suite *KeeperTestSuite) TestSlashOracle() {
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
 			ValidatorAddress: suite.ValAddr[i].String(),
-			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
+			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(100).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())

--- a/x/crosschain/keeper/msg_server_test.go
+++ b/x/crosschain/keeper/msg_server_test.go
@@ -102,7 +102,7 @@ func (suite *KeeperTestSuite) TestMsgBondedOracle() {
 				BridgerAddress:   suite.bridgerAddrs[oracleIndex].String(),
 				ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[oracleIndex].PublicKey),
 				ValidatorAddress: suite.ValAddr[oracleIndex].String(),
-				DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(3) + 1) * 10_000).MulRaw(1e18)),
+				DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(3) + 1) * 100).MulRaw(1e18)),
 				ChainName:        suite.chainName,
 			}
 
@@ -259,11 +259,11 @@ func (suite *KeeperTestSuite) TestMsgAddDelegate() {
 
 				slashFraction := suite.Keeper().GetSlashFraction(suite.Ctx)
 				slashAmount := sdkmath.LegacyNewDecFromInt(initDelegateAmount).Mul(slashFraction).MulInt64(oracle.SlashTimes).TruncateInt()
-				msg.Amount.Amount = slashAmount.Add(sdkmath.NewInt(1000).MulRaw(1e18))
+				msg.Amount.Amount = slashAmount.Add(sdkmath.NewInt(10).MulRaw(1e18))
 			},
 			pass: true,
 			expectDelegateAmount: func(msg *types.MsgAddDelegate) sdkmath.Int {
-				return initDelegateAmount.Add(sdkmath.NewInt(1000).MulRaw(1e18))
+				return initDelegateAmount.Add(sdkmath.NewInt(10).MulRaw(1e18))
 			},
 		},
 	}
@@ -337,7 +337,7 @@ func (suite *KeeperTestSuite) TestMsgAddDelegate() {
 }
 
 func (suite *KeeperTestSuite) TestMsgEditBridger() {
-	delegateAmount := sdkmath.NewInt((tmrand.Int63n(5) + 1) * 10_000).MulRaw(1e18)
+	delegateAmount := sdkmath.NewInt((tmrand.Int63n(5) + 1) * 100).MulRaw(1e18)
 	for i := range suite.oracleAddrs {
 		bondedMsg := &types.MsgBondedOracle{
 			OracleAddress:    suite.oracleAddrs[i].String(),
@@ -378,7 +378,7 @@ func (suite *KeeperTestSuite) TestMsgSetOracleSetConfirm() {
 		BridgerAddress:   suite.bridgerAddrs[0].String(),
 		ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[0].PublicKey),
 		ValidatorAddress: suite.ValAddr[0].String(),
-		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 10_000).MulRaw(1e18)),
+		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 100).MulRaw(1e18)),
 		ChainName:        suite.chainName,
 	}
 	_, err := suite.MsgServer().BondedOracle(suite.Ctx, normalMsg)
@@ -500,7 +500,7 @@ func (suite *KeeperTestSuite) TestClaimWithOracleOnline() {
 		BridgerAddress:   suite.bridgerAddrs[0].String(),
 		ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[0].PublicKey),
 		ValidatorAddress: suite.ValAddr[0].String(),
-		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 10_000).MulRaw(1e18)),
+		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 100).MulRaw(1e18)),
 		ChainName:        suite.chainName,
 	}
 	_, err := suite.MsgServer().BondedOracle(suite.Ctx, normalMsg)
@@ -704,7 +704,7 @@ func (suite *KeeperTestSuite) TestClaimMsgGasConsumed() {
 					BridgerAddress:   suite.bridgerAddrs[i].String(),
 					ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
 					ValidatorAddress: suite.ValAddr[0].String(),
-					DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 10_000).MulRaw(1e18)),
+					DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 100).MulRaw(1e18)),
 					ChainName:        suite.chainName,
 				}
 				_, err := suite.MsgServer().BondedOracle(suite.Ctx, msg)
@@ -725,7 +725,7 @@ func (suite *KeeperTestSuite) TestClaimTest() {
 		BridgerAddress:   suite.bridgerAddrs[0].String(),
 		ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[0].PublicKey),
 		ValidatorAddress: suite.ValAddr[0].String(),
-		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 10_000).MulRaw(1e18)),
+		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 100).MulRaw(1e18)),
 		ChainName:        suite.chainName,
 	}
 	_, err := suite.MsgServer().BondedOracle(suite.Ctx, normalMsg)
@@ -875,7 +875,7 @@ func (suite *KeeperTestSuite) BondedOracle() {
 		BridgerAddress:   suite.bridgerAddrs[0].String(),
 		ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[0].PublicKey),
 		ValidatorAddress: suite.ValAddr[0].String(),
-		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 10_000).MulRaw(1e18)),
+		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt((tmrand.Int63n(5) + 1) * 100).MulRaw(1e18)),
 		ChainName:        suite.chainName,
 	})
 	suite.Require().NoError(err)

--- a/x/crosschain/types/params.go
+++ b/x/crosschain/types/params.go
@@ -37,7 +37,7 @@ func DefaultParams() Params {
 		SlashFraction:                     sdkmath.LegacyNewDecWithPrec(8, 1), // 80%
 		OracleSetUpdatePowerChangePercent: sdkmath.LegacyNewDecWithPrec(1, 1), // 10%
 		IbcTransferTimeoutHeight:          20_000,
-		DelegateThreshold:                 NewDelegateAmount(sdkmath.NewInt(10_000).MulRaw(1e18)),
+		DelegateThreshold:                 NewDelegateAmount(sdkmath.NewInt(100).MulRaw(1e18)),
 		DelegateMultiple:                  DefaultOracleDelegateThreshold,
 		BridgeCallTimeout:                 DefBridgeCallTimeout,
 		BridgeCallMaxGasLimit:             MaxGasLimit,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Configuration Updates**
  - Reduced delegation threshold across multiple blockchain configurations
  - Lowered minimum delegate amount from 10,000 to 100 units

- **System Improvements**
  - Enhanced oracle delegation parameter migration process
  - Updated default crosschain delegation parameters

- **Testing**
  - Adjusted test cases to reflect new delegation amount calculations

These changes optimize the delegation mechanism and reduce entry barriers for network participants across various blockchain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->