### PR TITLE
refactor(ibctransfer): convert FX to apundiai on OnAck error or Timeout

### DIFF
--- a/app/upgrade_test.go
+++ b/app/upgrade_test.go
@@ -191,6 +191,20 @@ func checkAppUpgrade(t *testing.T, ctx sdk.Context, myApp *app.App, bdd BeforeUp
 	checkModulesData(t, ctx, myApp)
 }
 
+func checkIBCTransferModule(t *testing.T, ctx sdk.Context, myApp *app.App) {
+	t.Helper()
+	escrowDenomsMap := nextversion.GetMigrateEscrowDenoms(ctx.ChainID())
+	require.NotEmpty(t, escrowDenomsMap)
+
+	for oldDenom, newDenom := range escrowDenomsMap {
+		coin := myApp.IBCTransferKeeper.GetTotalEscrowForDenom(ctx, oldDenom)
+		require.True(t, coin.IsZero())
+
+		coin = myApp.IBCTransferKeeper.GetTotalEscrowForDenom(ctx, newDenom)
+		require.False(t, coin.IsZero())
+	}
+}
+
 func checkCrisisModule(t *testing.T, ctx sdk.Context, myApp *app.App) {
 	t.Helper()
 	constantFee, err := myApp.CrisisKeeper.ConstantFee.Get(ctx)
@@ -639,6 +653,7 @@ func checkModulesData(t *testing.T, ctx sdk.Context, myApp *app.App) {
 	checkCrisisModule(t, ctx, myApp)
 	checkBankModule(t, ctx, myApp)
 	checkEvmParams(t, ctx, myApp)
+	checkIBCTransferModule(t, ctx, myApp)
 }
 
 func checkEvmParams(t *testing.T, ctx sdk.Context, myApp *app.App) {

--- a/x/ibc/middleware/keeper/relay_test.go
+++ b/x/ibc/middleware/keeper/relay_test.go
@@ -1,17 +1,26 @@
 package keeper_test
 
 import (
+	"bytes"
 	"fmt"
+	"testing"
 
 	sdkmath "cosmossdk.io/math"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/jsonpb"
+	"github.com/cosmos/gogoproto/proto"
 	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pundiai/fx-core/v8/testutil/helpers"
+	fxtypes "github.com/pundiai/fx-core/v8/types"
 	crosschaintypes "github.com/pundiai/fx-core/v8/x/crosschain/types"
+	"github.com/pundiai/fx-core/v8/x/ibc/middleware/keeper"
+	"github.com/pundiai/fx-core/v8/x/ibc/middleware/types"
 )
 
 func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
@@ -63,7 +72,7 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 			if tc.expPass {
 				suite.Require().NoError(err, "packet: %s", string(packet.GetData()))
 			} else {
-				suite.Require().NotNil(err)
+				suite.Require().Error(err)
 				suite.Require().Equalf(tc.errorStr, err.Error(), "packet: %s", string(packet.GetData()))
 			}
 			if tc.checkBalance {
@@ -135,4 +144,107 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 func (suite *KeeperTestSuite) mintCoin(address sdk.AccAddress, coins ...sdk.Coin) {
 	suite.Require().NoError(suite.bankKeeper.MintCoins(suite.Ctx, transfertypes.ModuleName, coins))
 	suite.Require().NoError(suite.bankKeeper.SendCoinsFromModuleToAccount(suite.Ctx, transfertypes.ModuleName, address, coins))
+}
+
+func TestUnmarshalAckPacketData(t *testing.T) {
+	normalData := types.FungibleTokenPacketData{
+		Denom:  fxtypes.IBCFXDenom,
+		Amount: "1000",
+	}
+	normalExpected := transfertypes.FungibleTokenPacketData{
+		Denom:  fxtypes.DefaultDenom,
+		Amount: "10",
+	}
+
+	testCases := []struct {
+		name     string
+		malleate func(data types.FungibleTokenPacketData, exp transfertypes.FungibleTokenPacketData) (types.FungibleTokenPacketData, transfertypes.FungibleTokenPacketData)
+		exp      transfertypes.FungibleTokenPacketData
+		isZero   bool
+		err      error
+	}{
+		{
+			name:   "normal",
+			exp:    normalExpected,
+			isZero: false,
+		},
+		{
+			name: "normal - a pundiai is zero",
+			malleate: func(data types.FungibleTokenPacketData, exp transfertypes.FungibleTokenPacketData) (types.FungibleTokenPacketData, transfertypes.FungibleTokenPacketData) {
+				data.Amount = "99"
+				exp.Amount = "0"
+				return data, exp
+			},
+			isZero: true,
+		},
+		{
+			name: "normal - amount + fee",
+			malleate: func(data types.FungibleTokenPacketData, exp transfertypes.FungibleTokenPacketData) (types.FungibleTokenPacketData, transfertypes.FungibleTokenPacketData) {
+				data.Amount = "1000"
+				data.Fee = "100"
+				data.Router = tmrand.Str(10)
+				exp.Amount = "11"
+				return data, exp
+			},
+			isZero: false,
+		},
+		{
+			name: "normal - another denom with fee",
+			malleate: func(data types.FungibleTokenPacketData, exp transfertypes.FungibleTokenPacketData) (types.FungibleTokenPacketData, transfertypes.FungibleTokenPacketData) {
+				denom := tmrand.Str(10)
+				data.Denom = denom
+				data.Amount = "1000"
+				data.Fee = "1000"
+				data.Router = tmrand.Str(10)
+
+				exp.Denom = denom
+				exp.Amount = "2000"
+				return data, exp
+			},
+			isZero: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tcData := normalData
+			if tc.malleate != nil {
+				tcData, tc.exp = tc.malleate(tcData, normalExpected)
+			}
+			packetDateByte, err := sdk.SortJSON(mustProtoMarshalJSON(&tcData))
+			require.NoError(t, err)
+			data, isZeroAmount, err := keeper.UnmarshalAckPacketData(packetDateByte)
+			if tc.err != nil {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, data)
+			require.Equal(t, tc.isZero, isZeroAmount)
+		})
+	}
+}
+
+func mustProtoMarshalJSON(msg proto.Message) []byte {
+	anyResolver := codectypes.NewInterfaceRegistry()
+
+	// EmitDefaults is set to false to prevent marshaling of unpopulated fields (memo)
+	// OrigName and the anyResovler match the fields the original SDK function would expect
+	// in order to minimize changes.
+
+	// OrigName is true since there is no particular reason to use camel case
+	// The any resolver is empty, but provided anyways.
+	jm := &jsonpb.Marshaler{OrigName: true, EmitDefaults: false, AnyResolver: anyResolver}
+
+	err := codectypes.UnpackInterfaces(msg, codectypes.ProtoJSONPacker{JSONPBMarshaler: jm})
+	if err != nil {
+		panic(err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err := jm.Marshal(buf, msg); err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced IBC transfer module testing with new validation function
	- Added token migration logic for escrow denominations during upgrades
	- Improved packet data handling in IBC middleware

- **Tests**
	- Added comprehensive test cases for packet data unmarshalling
	- Updated test error handling for IBC acknowledgment scenarios

- **Refactor**
	- Centralized packet data processing logic
	- Streamlined IBC transfer module upgrade procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->