### PR TITLE
refactor(x/crosschain): reset the block height when ResendTimeoutOutgoingTxBatch

### DIFF
--- a/x/crosschain/keeper/outgoing_tx.go
+++ b/x/crosschain/keeper/outgoing_tx.go
@@ -172,6 +172,7 @@ func (k Keeper) ResendTimeoutOutgoingTxBatch(ctx sdk.Context, batch *types.Outgo
 		return types.ErrInvalid.Wrapf("batch timeout height")
 	}
 	batch.BatchTimeout = batchTimeout
+	batch.Block = uint64(ctx.BlockHeight())
 	batch.BatchNonce = k.autoIncrementID(ctx, types.KeyLastOutgoingBatchID)
 	if err := k.StoreBatch(ctx, batch); err != nil {
 		return err
@@ -200,29 +201,6 @@ func (k Keeper) IterateOutgoingTxBatches(ctx sdk.Context, cb func(batch *types.O
 			break
 		}
 	}
-}
-
-// GetOutgoingTxBatches used in testing
-func (k Keeper) GetOutgoingTxBatches(ctx sdk.Context) (out []*types.OutgoingTxBatch) {
-	k.IterateOutgoingTxBatches(ctx, func(batch *types.OutgoingTxBatch) bool {
-		out = append(out, batch)
-		return false
-	})
-	return
-}
-
-// GetLastOutgoingBatchByToken gets the latest outgoing tx batch by token type
-func (k Keeper) GetLastOutgoingBatchByToken(ctx sdk.Context, token string) *types.OutgoingTxBatch {
-	var lastBatch *types.OutgoingTxBatch
-	lastNonce := uint64(0)
-	k.IterateOutgoingTxBatches(ctx, func(batch *types.OutgoingTxBatch) bool {
-		if batch.TokenContract == token && batch.BatchNonce > lastNonce {
-			lastBatch = batch
-			lastNonce = batch.BatchNonce
-		}
-		return false
-	})
-	return lastBatch
 }
 
 // IterateBatchByBlockHeight iterates through all Batch by block in the half-open interval [start,end)

--- a/x/crosschain/keeper/outgoing_tx_test.go
+++ b/x/crosschain/keeper/outgoing_tx_test.go
@@ -1,20 +1,17 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
+	tmrand "github.com/cometbft/cometbft/libs/rand"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/pundiai/fx-core/v8/testutil/helpers"
 	"github.com/pundiai/fx-core/v8/x/crosschain/types"
 )
 
 func (suite *KeeperTestSuite) TestKeeper_IterateOutgoingTxBatches() {
-	tokenContract := helpers.GenExternalAddr(suite.chainName)
 	batchNumber := 3
-	for i := 1; i <= batchNumber; i++ {
-		err := suite.Keeper().StoreBatch(suite.Ctx, &types.OutgoingTxBatch{
-			BatchNonce:    uint64(i),
-			TokenContract: tokenContract,
-		})
-		suite.NoError(err)
-	}
+	suite.addOutgoingTxBatchs(batchNumber, helpers.GenExternalAddr(suite.chainName))
 	batchList := make([]*types.OutgoingTxBatch, 0)
 	suite.Keeper().IterateOutgoingTxBatches(suite.Ctx, func(batch *types.OutgoingTxBatch) bool {
 		batchList = append(batchList, batch)
@@ -22,5 +19,58 @@ func (suite *KeeperTestSuite) TestKeeper_IterateOutgoingTxBatches() {
 	})
 	for i := 0; i < batchNumber; i++ {
 		suite.Equal(batchList[i].BatchNonce, uint64(i+1))
+	}
+}
+
+func (suite *KeeperTestSuite) TestResendTimeoutOutgoingTxBatch() {
+	tokenContract := helpers.GenExternalAddr(suite.chainName)
+	suite.addOutgoingTxBatchs(5, tokenContract)
+	storeKey := suite.App.GetKVStoreKey()[suite.Keeper().ModuleName()]
+	// set last batch id to 6
+	suite.Ctx.KVStore(storeKey).Set(types.KeyLastOutgoingBatchID, sdk.Uint64ToBigEndian(6))
+
+	bz := suite.Ctx.KVStore(storeKey).Get(types.KeyLastOutgoingBatchID)
+	suite.EqualValues(6, sdk.BigEndianToUint64(bz))
+
+	suite.Commit(3)
+	// if batchNonce 5 is executed, 1,2,3,4 will be resend
+	err := suite.Keeper().OutgoingTxBatchExecuted(suite.Ctx, tokenContract, 5)
+	suite.NoError(err)
+
+	actualBatchList := make([]uint64, 0, 4)
+	suite.Keeper().IterateOutgoingTxBatches(suite.Ctx, func(batch *types.OutgoingTxBatch) bool {
+		suite.EqualValues(uint64(suite.Ctx.BlockHeight()), batch.Block)
+		actualBatchList = append(actualBatchList, batch.BatchNonce)
+		return false
+	})
+	// expected batch 6,7,8,9
+	suite.EqualValues([]uint64{6, 7, 8, 9}, actualBatchList)
+}
+
+func (suite *KeeperTestSuite) addOutgoingTxBatchs(batchNumber int, tokenContract string) {
+	for i := 1; i <= batchNumber; i++ {
+		err := suite.Keeper().StoreBatch(suite.Ctx, &types.OutgoingTxBatch{
+			// save batch with same block height
+
+			Block:         1,
+			BatchNonce:    uint64(i),
+			TokenContract: tokenContract,
+			Transactions: []*types.OutgoingTransferTx{
+				{
+					Id:          1,
+					Sender:      helpers.GenAccAddress().String(),
+					DestAddress: helpers.GenExternalAddr(suite.chainName),
+					Token: types.ERC20Token{
+						Contract: tokenContract,
+						Amount:   sdkmath.NewInt(tmrand.Int63()),
+					},
+					Fee: types.ERC20Token{
+						Contract: tokenContract,
+						Amount:   sdkmath.NewInt(tmrand.Int63()),
+					},
+				},
+			},
+		})
+		suite.NoError(err)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of outgoing transaction batches to record the current block height during timeout processing.
  - Removed unused retrieval operations to streamline the internal workflow.

- **Tests**
  - Expanded the test suite with new cases and helper methods to ensure that batch resending on timeout operates as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->