### PR TITLE
feat: add base64 Pubkeys from cli

### DIFF
--- a/client/cli/keys/add.go
+++ b/client/cli/keys/add.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/input"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
@@ -27,16 +29,17 @@ import (
 )
 
 const (
-	flagInteractive = "interactive"
-	flagRecover     = "recover"
-	flagNoBackup    = "no-backup"
-	flagCoinType    = "coin-type"
-	flagAccount     = "account"
-	flagIndex       = "index"
-	flagMultisig    = "multisig"
-	flagNoSort      = "nosort"
-	flagHDPath      = "hd-path"
-	flagMnemonicSrc = "source"
+	flagInteractive  = "interactive"
+	flagRecover      = "recover"
+	flagNoBackup     = "no-backup"
+	flagCoinType     = "coin-type"
+	flagAccount      = "account"
+	flagIndex        = "index"
+	flagMultisig     = "multisig"
+	flagNoSort       = "nosort"
+	flagHDPath       = "hd-path"
+	flagPubKeyBase64 = "pubkey-base64"
+	flagMnemonicSrc  = "source"
 )
 
 // AddKeyCommand defines a keys command to add a generated or recovered private key to keybase.
@@ -71,6 +74,7 @@ Example:
 	f.Int(flagMultiSigThreshold, 1, "K out of N required signatures. For use in conjunction with --multisig")
 	f.Bool(flagNoSort, false, "Keys passed to --multisig are taken in the order they're supplied")
 	f.String(FlagPublicKey, "", "Parse a public key in JSON format and saves key info to <name> file.")
+	f.String(flagPubKeyBase64, "", "Parse a public key in base64 format and saves key info.")
 	f.BoolP(flagInteractive, "i", false, "Interactively prompt user for BIP39 passphrase and mnemonic")
 	f.Bool(flags.FlagUseLedger, false, "Store a local reference to a private key on a Ledger device")
 	f.Bool(flagRecover, false, "Provide seed phrase to recover existing key instead of creating")
@@ -85,7 +89,7 @@ Example:
 
 	// support old flags name for backwards compatibility
 	f.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
-		if name == "algo" {
+		if name == flags.FlagKeyAlgorithm {
 			name = flags.FlagKeyType
 		}
 		return pflag.NormalizedName(name)
@@ -193,19 +197,55 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 	}
 
 	pubKey, _ := cmd.Flags().GetString(FlagPublicKey)
+	pubKeyBase64, _ := cmd.Flags().GetString(flagPubKeyBase64)
+	if pubKey != "" && pubKeyBase64 != "" {
+		return fmt.Errorf(`flags %s and %s cannot be used simultaneously`, FlagPublicKey, flagPubKeyBase64)
+	}
 	if pubKey != "" {
 		var pk cryptotypes.PubKey
-		err = ctx.Codec.UnmarshalInterfaceJSON([]byte(pubKey), &pk)
+		if err = ctx.Codec.UnmarshalInterfaceJSON([]byte(pubKey), &pk); err != nil {
+			return err
+		}
+
+		k, err := kb.SaveOfflineKey(name, pk)
 		if err != nil {
 			return err
 		}
 
-		info, err := kb.SaveOfflineKey(name, pk)
+		return printCreate(cmd, k, false, "", outputFormat)
+	}
+
+	if pubKeyBase64 != "" {
+		b64, err := base64.StdEncoding.DecodeString(pubKeyBase64)
 		if err != nil {
 			return err
 		}
 
-		return printCreate(cmd, info, false, "", outputFormat)
+		var pk cryptotypes.PubKey
+		// create an empty pubkey in order to get the algo TypeUrl.
+		tempAny, err := codectypes.NewAnyWithValue(algo.Generate()([]byte{}).PubKey())
+		if err != nil {
+			return err
+		}
+
+		jsonPub, err := json.Marshal(struct {
+			Type string `json:"@type,omitempty"`
+			Key  string `json:"key,omitempty"`
+		}{tempAny.TypeUrl, string(b64)})
+		if err != nil {
+			return fmt.Errorf("failed to JSON marshal typeURL and base64 key: %w", err)
+		}
+
+		if err = ctx.Codec.UnmarshalInterfaceJSON(jsonPub, &pk); err != nil {
+			return err
+		}
+
+		k, err := kb.SaveOfflineKey(name, pk)
+		if err != nil {
+			return fmt.Errorf("failed to save offline key: %w", err)
+		}
+
+		return printCreate(cmd, k, false, "", outputFormat)
 	}
 
 	coinType, _ := cmd.Flags().GetUint32(flagCoinType)
@@ -272,7 +312,7 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 	}
 
 	if len(mnemonic) == 0 {
-		// read entropy seed straight from tmcrypto.Rand and convert to mnemonic
+		// read entropy seed straight from cmtcrypto.Rand and convert to mnemonic
 		entropySeed, err := bip39.NewEntropy(256)
 		if err != nil {
 			return err
@@ -326,7 +366,7 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 
 func printCreate(cmd *cobra.Command, k *keyring.Record, showMnemonic bool, mnemonic, outputFormat string) error {
 	switch outputFormat {
-	case OutputFormatText:
+	case flags.OutputFormatText:
 		output, err := MkAccKeyOutput(k)
 		if err != nil {
 			return err
@@ -344,7 +384,7 @@ func printCreate(cmd *cobra.Command, k *keyring.Record, showMnemonic bool, mnemo
 				return fmt.Errorf("failed to print mnemonic: %w", err)
 			}
 		}
-	case OutputFormatJSON:
+	case flags.OutputFormatJSON:
 		out, err := MkAccKeyOutput(k)
 		if err != nil {
 			return err

--- a/client/cli/keys/output.go
+++ b/client/cli/keys/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -14,12 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/evmos/ethermint/crypto/ethsecp256k1"
 	"gopkg.in/yaml.v2"
-)
-
-// available output formats.
-const (
-	OutputFormatText = "text"
-	OutputFormatJSON = "json"
 )
 
 // Use protobuf interface marshaler rather then generic JSON
@@ -108,14 +103,14 @@ func MkAccKeysOutput(records []*keyring.Record) ([]KeyOutput, error) {
 
 func printInfo(w io.Writer, kos interface{}, output string) {
 	switch output {
-	case OutputFormatText:
+	case flags.OutputFormatText:
 		out, err := yaml.Marshal(&kos)
 		if err != nil {
 			panic(err)
 		}
 		_, _ = fmt.Fprintln(w, string(out))
 
-	case OutputFormatJSON:
+	case flags.OutputFormatJSON:
 		out, err := json.Marshal(kos)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `--pubkey-base64` option to allow adding public keys via a base64 string.

- **Bug Fixes**
	- Improved error handling by preventing the simultaneous use of `--pubkey` and `--pubkey-base64`.

- **Refactor**
	- Standardized output formatting to align with externally defined configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->