### PR TITLE
chore(hardhat): migrate to Etherscan v2 API

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -141,15 +141,7 @@ const config: HardhatUserConfig = {
     ],
   },
   etherscan: {
-    apiKey: {
-      ethereum: `${process.env.ETHERSCAN_API_KEY}`,
-      base: `${process.env.ETHERSCAN_API_KEY}`,
-      bsc: `${process.env.ETHERSCAN_API_KEY}`,
-      sepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      arbitrumSepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      optimisticSepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      baseSepolia: `${process.env.ETHERSCAN_API_KEY}`,
-    },
+    apiKey: `${process.env.ETHERSCAN_API_KEY}`,
     customChains: [
       {
         network: "ethereum",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified configuration for network API keys, with no impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->